### PR TITLE
don't load proofs in memory + some bug fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
         dedukti-version: [2.7]
         lambdapi-version: [master]
         dune-version: [3.7.0]
-        why3-version: [1.5.1]
     runs-on: ubuntu-latest
     steps:
     # actions/checkout must be done BEFORE avsm/setup-ocaml
@@ -37,7 +36,6 @@ jobs:
         run: |
           git clone --depth 1 -b ${{ matrix.lambdapi-version }} https://github.com/Deducteam/lambdapi
           opam pin lambdapi lambdapi
-          opam pin -y add why3 ${{ matrix.why3-version }}
           opam install -y lambdapi
       - name: Get hol-light and patch it
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
         dedukti-version: [2.7]
         lambdapi-version: [master]
         dune-version: [3.7.0]
+        why3-version: [1.5.1]
     runs-on: ubuntu-latest
     steps:
     # actions/checkout must be done BEFORE avsm/setup-ocaml
@@ -23,7 +24,7 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
       - name: Install dune
-        run: opam install dune.${{ matrix.dune-version }}
+        run: opam install -y dune.${{ matrix.dune-version }}
       - name: Compile hol2dk
         run: |
           eval `opam env`
@@ -31,12 +32,13 @@ jobs:
       - name: Install hol-light dependencies, dedukti
         run: |
           sudo apt-get install -y libipc-system-simple-perl libstring-shellquote-perl
-          opam install camlp5.${{ matrix.camlp5-version }} num ocamlfind dedukti.${{ matrix.dedukti-version }} #lambdapi.${{ matrix.lambdapi-version }}
+          opam install -y camlp5.${{ matrix.camlp5-version }} num ocamlfind dedukti.${{ matrix.dedukti-version }} #lambdapi.${{ matrix.lambdapi-version }}
       - name: Install lambdapi
         run: |
           git clone --depth 1 -b ${{ matrix.lambdapi-version }} https://github.com/Deducteam/lambdapi
-          opam pin lambdapi lambdapi
-          opam install lambdapi
+          opam pin -y lambdapi lambdapi
+          opam pin -y add why3 ${{ matrix.why3-version }}
+          opam install -y lambdapi
       - name: Get hol-light and patch it
         run: |
           git clone --depth 1 https://github.com/jrh13/hol-light

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install lambdapi
         run: |
           git clone --depth 1 -b ${{ matrix.lambdapi-version }} https://github.com/Deducteam/lambdapi
-          opam pin -y lambdapi lambdapi
+          opam pin lambdapi lambdapi
           opam pin -y add why3 ${{ matrix.why3-version }}
           opam install -y lambdapi
       - name: Get hol-light and patch it

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 _build/
+\#*
+*.lp
+*.dk
+*.dump
+lambdapi.pkg

--- a/README.md
+++ b/README.md
@@ -180,12 +180,12 @@ for checking hol.ml:
 -    with proof dumping: 3.8 Go 1m51s (+39%)
 
 On `hol.ml` until `arith.ml` (by commenting from `loads "wf.ml"` to the end):
-- proof checking and dumping: 12.8s 101 Mo
+- proof dumping: 13s 101 Mo
 - number of proof steps: 408777
-- dk file generation: 22s 99 Mo
+- dk file generation: 24s 99 Mo
 - checking time with dk check: 14s
 - checking time with kocheck -j 7: 23s
-- lp file generation: 14s 69 Mo
+- lp file generation: 16s 69 Mo
 - checking time with lambdapi: 2m
 
 Getting information on HOL-Light files and theorems
@@ -252,8 +252,7 @@ sed -i -e 's/.*Q0.*//' -e 's/START_ND*)//' -e 's/(*END_ND//' fusion.ml bool.ml
 ```
 
 Results on `hol.ml` until `arith.ml` (by commenting from `loads "wf.ml"` to the end):
-- ocaml proof checking: 12.5s
-- ocaml proof checking and recording: 13.2s
+- ocaml proof dumping: 13.2s
 - number of proof steps: 564351
 - proof dumping: 1.4s 157 Mo
 - dk file generation: 45s 153 Mo

--- a/README.md
+++ b/README.md
@@ -108,7 +108,14 @@ dune exec -- hol2dk $hol-light-dir/signature.dump $hol-light-dir/proofs.dump fil
 ```
 
 generates the files `file_types.lp`, `file_terms.lp` and `file.lp`
-from the dumped files.
+from the dump files given in arguments.
+
+It is possible to get the proof of a single theorem (useful for debugging) by giving its number as additional argument:
+
+```
+cd $hol2dk-dir
+dune exec -- hol2dk $hol-light-dir/signature.dump $hol-light-dir/proofs.dump file.lp $theorem_number
+```
 
 Checking the generated dk file
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ dune exec -- hol2dk $hol-light-dir/signature.dump $hol-light-dir/proofs.dump fil
 generates the files `file_types.lp`, `file_terms.lp` and `file.lp`
 from the dump files given in arguments.
 
-It is possible to get the proof of a single theorem (useful for debugging) by giving its number as additional argument:
+It is possible to get the proof of a single theorem by giving its number as additional argument (useful for debugging):
 
 ```
 cd $hol2dk-dir

--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ for checking hol.ml:
 On `hol.ml` until `arith.ml` (by commenting from `loads "wf.ml"` to the end):
 - proof dumping: 13s 101 Mo
 - number of proof steps: 408777
-- dk file generation: 24s 99 Mo
-- checking time with dk check: 14s
-- checking time with kocheck -j 7: 23s
-- lp file generation: 16s 69 Mo
+- dk file generation: 29s 99 Mo
+- checking time with dk check: 19s
+- checking time with kocheck -j 7: 14s
+- lp file generation: 17s 69 Mo
 - checking time with lambdapi: 2m
 
 Getting information on HOL-Light files and theorems

--- a/dump-proofs
+++ b/dump-proofs
@@ -1,16 +1,11 @@
 #!/bin/sh
 
-if test $# -lt 1 -o $# -gt 2; then echo "usage: $0 file.[mh]l [proof_number]"; exit 1; fi
+if test $# -lt 1 -o $# -gt 2; then echo "usage: $0 file.[mh]l"; exit 1; fi
 
 case $1 in
     *.ml) f=${1%.ml};;
     *.hl) f=${1%.hl};;
     *) echo "$1: wrong file extension (should be .ml or .hl)"; exit 1;;
-esac
-
-case "$2" in
-    "") range='All';;
-    *) range="(Upto $2)";;
 esac
 
 cat << EOF | ocaml

--- a/fusion.ml
+++ b/fusion.ml
@@ -734,7 +734,8 @@ module Hol : Hol_kernel = struct
 
   let SPEC t (Sequent(asl,c,k)) =
     match c with
-    | Comb(Const("!",_),p) -> new_theorem asl (Comb(p,t)) (Pspec(t,k))
+    | Comb(Const("!",Tyapp(_,[Tyapp(_,[b;_]);_])),p) when b = type_of t ->
+      new_theorem asl (Comb(p,t)) (Pspec(t,k))
     | _ -> failwith "SPEC"
   ;;
 

--- a/main.ml
+++ b/main.ml
@@ -39,10 +39,11 @@ let main() =
   if n = 2 then
     begin
       log "read %s ...\n%!" dump_file;
-      let f _ _ = () in
+      let f _ p = count_thm_uses p; count_rule_uses p in
       iter_proofs f;
-      (*log "compute statistics ...\n";
-      print_proof_stats();*)
+      log "compute statistics ...\n";
+      print_thm_uses_histogram();
+      print_rule_uses();
       exit 0
     end;
 

--- a/main.ml
+++ b/main.ml
@@ -24,34 +24,29 @@ let main() =
   let dump_file = Sys.argv.(1) in
   log "read %s ...\n%!" dump_file;
   let ic = open_in_bin dump_file in
-  let read() = Marshal.from_channel ic in
-  the_type_constants := read();
-  the_term_constants := ("el",aty)::read();
-  the_axioms := read();
-  the_definitions := read();
-  let nb_proofs = read() in
-  Printf.printf "%d proof steps\n%!" nb_proofs;
-  the_proofs := Array.make nb_proofs dummy_proof;
+  the_type_constants := input_value ic;
+  the_term_constants := ("el",aty)::input_value ic;
+  the_axioms := input_value ic;
+  the_definitions := input_value ic;
+  let nb_proofs = input_value ic in
+  log "%d proof steps\n%!" nb_proofs;
 
-  (* read proofs *)
-  begin
-    let dump_file = Sys.argv.(2) in
-    log "read %s ...\n%!" dump_file;
-    let ic = open_in_bin dump_file in
-    the_proofs_idx := -1;
-    try
-      while true do
-        let k = !the_proofs_idx + 1 in
-        Array.set (!the_proofs) k (Marshal.from_channel ic);
-        the_proofs_idx := k
-      done
-    with End_of_file -> close_in ic
-  end;
-  log "compute statistics ...\n";
-  print_proof_stats();
-  if n = 2 then exit 0;
+  (* set dump file for proofs *)
+  let dump_file = Sys.argv.(2) in
+  set_dump_file dump_file nb_proofs;
 
-  (* get filename and check file extension *)
+  (* if no output file is given, read proofs, print stats and exit *)
+  if n = 2 then
+    begin
+      log "read %s ...\n%!" dump_file;
+      let f _ _ = () in
+      iter_proofs f;
+      (*log "compute statistics ...\n";
+      print_proof_stats();*)
+      exit 0
+    end;
+
+  (* check file extension *)
   let filename = Sys.argv.(3) in
   let ext = Filename.extension filename in
   let dk =
@@ -66,7 +61,15 @@ let main() =
   let basename = Filename.chop_extension filename in
 
   (* generate output *)
-  let range = if n = 4 then Only (int_of_string Sys.argv.(4)) else All in
-  (if dk then Xdk.export_to_dk_file else Xlp.export_to_lp_file) basename range
+  let export = if dk then Xdk.export_to_dk_file else Xlp.export_to_lp_file in
+  let range =
+    if n = 4 then
+      let x = int_of_string Sys.argv.(4) in
+      log "read %s ...\n%!" dump_file;
+      for k = 0 to x-1 do ignore (proof_at k) done;
+      Only x
+    else All
+  in
+  export basename range
 
 let _ = main()

--- a/xdk.ml
+++ b/xdk.ml
@@ -266,6 +266,16 @@ let rename tvs =
   in rename
 ;;
 
+let rename tvs rmap t =
+  try rename tvs rmap t
+  with Failure _ as e ->
+    let typ = raw_typ in
+    let term = raw_term in
+    log "rename %a %a %a"
+      (olist typ) tvs (olist (opair term string)) rmap term t;
+    raise e
+;;
+
 let term =
   if !use_abbrev then
     fun tvs rmap oc t -> abbrev_term tvs oc (rename tvs rmap t)

--- a/xdk.ml
+++ b/xdk.ml
@@ -38,13 +38,12 @@ let name oc n = string oc (valid_name n);;
 
 let suffix s oc n = name oc (n ^ s);;
 
-let typ_name oc n = name oc n
+let typ_name = name
   (*match !stage with
   | Types | No_abbrev -> name oc n
   | _ -> out oc "%s_types.%a" !basename name n*)
-;;
 
-let cst_name oc n = name oc n
+let cst_name = name
   (*match !stage with
   | Terms | No_abbrev -> name oc n
   | _ -> out oc "%s_terms.%a" !basename name n*)
@@ -264,16 +263,6 @@ let rename tvs =
     | Abs(u,v) ->
        let rmap' = add_var rmap u in mk_abs(rename rmap' u,rename rmap' v)
   in rename
-;;
-
-let rename tvs rmap t =
-  try rename tvs rmap t
-  with Failure _ as e ->
-    let typ = raw_typ in
-    let term = raw_term in
-    log "rename %a %a %a"
-      (olist typ) tvs (olist (opair term string)) rmap term t;
-    raise e
 ;;
 
 let term =
@@ -502,8 +491,9 @@ let decl_sym oc (n,b) =
 ;;
 
 let decl_def oc th =
-  let t = concl th in
-  let rmap = renaming_map [] in (* definitions are closed *)
+  let t = concl th in (* definitions have no assumptions *)
+  let tvs = type_vars_in_term t in
+  let rmap = renaming_map tvs [] in (* definitions are closed *)
   match t with
   | Comb(Comb(Const("=",_),Const(n,_)),_) ->
      let tvs = type_vars_in_term t in
@@ -515,10 +505,10 @@ let decl_def oc th =
 
 let decl_axioms oc ths =
   let axiom i th =
-    let t = concl th in
+    let t = concl th in (* axioms have no assumptions *)
     let xs = frees t in
-    let rmap = renaming_map xs in
     let tvs = type_vars_in_term t in
+    let rmap = renaming_map tvs xs in
     out oc "def axiom_%d : %a%aPrf %a.\n" i
       (list (decl_typ_param tvs)) tvs  (list (decl_param tvs rmap)) xs
       (unabbrev_term tvs rmap) t
@@ -536,19 +526,18 @@ let theorem oc k p =
   (*log "theorem %d ...\n%!" k;*)
   let ts,t = dest_thm thm in
   let xs = freesl (t::ts) in
-  let rmap = renaming_map xs in
   let tvs = type_vars_in_thm thm in
-  (*out oc "(;rmap: %a;)" (list_sep "; " (pair raw_var string)) rmap;*)
+  let rmap = renaming_map tvs xs in
   let term = term tvs rmap in
   let hyps_typ oc ts =
     List.iteri (fun i t -> out oc "h%d : Prf %a -> " (i+1) term t) ts in
   let hyps oc ts =
     List.iteri (fun i t -> out oc "h%d : Prf %a => " (i+1) term t) ts in
-  out oc "thm thm_%d : %a%a%aPrf %a := %a%a%a%a.\n"
-    k (list (decl_typ_param tvs)) tvs
-    (list (decl_param tvs rmap)) xs hyps_typ ts term t
-    (list (typ_param tvs)) tvs (list (param tvs rmap)) xs hyps ts
-    (proof tvs rmap) p
+  out oc "thm thm_%d : %a%a%aPrf %a := %a%a%a%a.\n" k
+    (list (decl_typ_param tvs)) tvs  (list (decl_param tvs rmap)) xs
+    hyps_typ ts term t
+    (list (typ_param tvs)) tvs (list (param tvs rmap)) xs
+    hyps ts (proof tvs rmap) p
 ;;
 
 (* [theorem_as_axiom oc k p] outputs on [oc] the proof [p] of index
@@ -558,9 +547,8 @@ let theorem_as_axiom oc k p =
   (*log "theorem %d as axiom ...\n%!" k;*)
   let ts,t = dest_thm thm in
   let xs = freesl (t::ts) in
-  let rmap = renaming_map xs in
   let tvs = type_vars_in_thm thm in
-  (*out oc "(;rmap: %a;)" (list_sep "; " (pair raw_var string)) rmap;*)
+  let rmap = renaming_map tvs xs in
   let term = term tvs rmap in
   let hyps_typ oc ts =
     List.iteri (fun i t -> out oc "h%d : Prf %a -> " (i+1) term t) ts in
@@ -649,6 +637,7 @@ let export_to_dk_file f r =
   (*basename := f;*)
   reset_map_typ();
   reset_map_term();
+  update_reserved();
   update_map_const_typ_vars_pos();
   (* generate axioms and theorems *)
   let filename = f ^ "_proofs.dk" in
@@ -746,6 +735,7 @@ decl_axioms (axioms()) (list decl_def) (definitions())
 let export_to_dk_file_no_abbrev f r =
   use_abbrev := false;
   (*stage := No_abbrev;*)
+  update_reserved();
   update_map_const_typ_vars_pos();
   let filename = f ^ ".dk" in
   log "generate %s ...\n%!" filename;

--- a/xlp.ml
+++ b/xlp.ml
@@ -220,6 +220,14 @@ let rec rename rmap t =
      let rmap' = add_var rmap u in mk_abs(rename rmap' u,rename rmap' v)
 ;;
 
+let rename rmap t =
+  try rename rmap t
+  with Failure _ as e ->
+    let term = raw_term in
+    log "rename %a %a" (olist (opair term string)) rmap term t;
+    raise e
+;;
+
 let term =
   if !use_abbrev then fun rmap oc t -> abbrev_term oc (rename rmap t)
   else unabbrev_term

--- a/xproof.ml
+++ b/xproof.ml
@@ -86,73 +86,16 @@ let print_proof_stats() =
   done;
   log "number of mappings: %d\n" !nonzeros;
   (* Count the number of times each proof rule is used. *)
-  let index p =
-    let Proof(_,c) = p in
-    match c with
-    | Prefl _ -> 0
-    | Ptrans _ -> 1
-    | Pmkcomb _ -> 2
-    | Pabs _ -> 3
-    | Pbeta _ -> 4
-    | Passume _ -> 5
-    | Peqmp _ -> 6
-    | Pdeduct _ -> 7
-    | Pinst _ -> 8
-    | Pinstt _ -> 9
-    | Paxiom _ -> 10
-    | Pdef _ -> 11
-    | Pdeft _ -> 12
-    | Ptruth -> 13
-    | Pconj _ -> 14
-    | Pconjunct1 _ -> 15
-    | Pconjunct2 _ -> 16
-    | Pmp _ -> 17
-    | Pdisch _ -> 18
-    | Pspec _ -> 19
-    | Pgen _ -> 20
-    | Pexists _ -> 21
-    | Pdisj1 _ -> 22
-    | Pdisj2 _ -> 23
-    | Pdisj_cases _ -> 24
-  in
-  let name = function
-    | 0 -> "refl"
-    | 1 -> "trans"
-    | 2 -> "comb"
-    | 3 -> "abs"
-    | 4 -> "beta"
-    | 5 -> "assume"
-    | 6 -> "eqmp"
-    | 7 -> "deduct"
-    | 8 -> "term_subst"
-    | 9 -> "type_subst"
-    | 10 -> "axiom"
-    | 11 -> "sym_def"
-    | 12 -> "type_def"
-    | 13 -> "truth"
-    | 14 -> "conj"
-    | 15 -> "conjunct1"
-    | 16 -> "conjunct2"
-    | 17 -> "mp"
-    | 18 -> "disch"
-    | 19 -> "spec"
-    | 20 -> "gen"
-    | 21 -> "exists"
-    | 22 -> "disj1"
-    | 23 -> "disj2"
-    | 24 -> "disj_cases"
-    | _ -> assert false
-  in
   let rule_uses = Array.make 25 0 in
   let f k p =
-    let i = index p in
+    let i = code_of_proof p in
     let n = Array.get rule_uses i + 1 in
     Array.set rule_uses i n
   in
   iter_proofs f;
   let total = float_of_int (nb_proofs()) in
   let part n = float_of_int (100 * n) /. total in
-  let f i n = log "%10s %9d %2.f%%\n" (name i) n (part n) in
+  let f i n = log "%10s %9d %2.f%%\n" (name_of_code i) n (part n) in
   Array.iteri f rule_uses;
   log "number of proof steps: %d\nnumber of unused theorems: %d (%2.f%%)\n"
     (nb_proofs()) hist.(0) (part hist.(0))

--- a/xproof.ml
+++ b/xproof.ml
@@ -6,24 +6,23 @@ open Fusion
 open Xlib
 open Xprelude
 
-(*
-let the_proofs : proof array ref = ref [||]
-let proof_at k = Array.get (!the_proofs) k
-let the_proofs_idx : int ref = ref (-1)
-let nb_proofs() = !the_proofs_idx + 1
-let iter_proofs f = for k = 0 to !the_proofs_idx do f k (proof_at k) done
-*)
+let ic_dump : in_channel ref = ref stdin;;
+let pos_dump : int array ref = ref [||];;
+let thm_uses : int array ref = ref [||];;
+let thm_uses_max : int ref = ref (-1);;
+let thm_uses_argmax : int ref = ref (-1);;
+let rule_uses : int array = Array.make 25 0;;
 
-let ic_dump : in_channel ref = ref stdin
-let pos_dump : int array ref = ref [||]
-
-let set_dump_file filename n =
+let set_dump_file (filename : string) (n : int) : unit =
   let ic = open_in_bin filename in
   ic_dump := ic;
-  pos_dump := Array.make n (-1)
+  pos_dump := Array.make n (-1);
+  thm_uses :=  Array.make n 0
+;;
 
-let nb_proofs() = Array.length !pos_dump
+let nb_proofs() : int = Array.length !pos_dump;;
 
+(* [proof_at k] returns the proof of index [k]. *)
 let proof_at k =
   let ic = !ic_dump in
   let pos = !pos_dump in
@@ -43,8 +42,11 @@ let proof_at k =
       seek_in ic cur_pos;
       prf
     end
+;;
 
-let iter_proofs f =
+(* [iter_proofs f] runs [f k (proof_at k)] on all proof index [k] from
+   0 to [nb_proofs() - 1]. *)
+let iter_proofs (f : int -> proof -> unit) =
   let idx = ref 0 in
   try
     while !idx < Array.length !pos_dump do
@@ -55,48 +57,41 @@ let iter_proofs f =
   with Failure _ as e ->
     log "proof %d\n%!" !idx;
     raise e
+;;
 
-(****************************************************************************)
-(* Print statistics on proofs. *)
-(****************************************************************************)
-
-let print_proof_stats() =
-  (* Array for mapping each proof index to the number of times it is used. *)
-  let proof_uses = Array.make (nb_proofs()) 0 in
-  (* Maximum number of times a proof is used. *)
-  let max = ref 0 in
-  (* Actually compute [proof_uses]. *)
+let count_thm_uses : proof -> unit=
   let use k =
-    let n = Array.get proof_uses k + 1 in
-    Array.set proof_uses k n;
-    if n > !max then max := n
+    let n = Array.get !thm_uses k + 1 in
+    Array.set !thm_uses k n;
+    if n > !thm_uses_max then (thm_uses_max := n; thm_uses_argmax := k)
   in
-  iter_proofs (fun _ p -> List.iter use (deps p));
-  (* Array for mapping to each number n <= !max the number of proofs which
-     is used n times. *)
-  let hist = Array.make (!max + 1) 0 in
+  fun p -> List.iter use (deps p)
+;;
+
+let count_rule_uses (p : proof) : unit =
+  let i = code_of_proof p in
+  Array.set rule_uses i (Array.get rule_uses i + 1)
+;;
+
+(* Prints on stdout the number of theorems that are used i times, for
+   each i from 0 to !thm_uses_max. *)
+let print_thm_uses_histogram() : unit =
+  let hist = Array.make (!thm_uses_max + 1) 0 in
   let f nb_uses = Array.set hist nb_uses (Array.get hist nb_uses + 1) in
-  Array.iter f proof_uses;
-  (* Print histogram *)
-  log "i: n means that n proofs are used i times\n";
+  Array.iter f !thm_uses;
+  log "(* \"i: n\" means that n proofs are used i times *)\n";
   let nonzeros = ref 0 in
-  for i=0 to !max do
+  for i=0 to !thm_uses_max do
     let n = Array.get hist i in
-    if n>0 then (incr nonzeros; log "%d: %d\n" i n)
+    if n > 0 then (incr nonzeros; log "%d: %d\n" i n)
   done;
   log "number of mappings: %d\n" !nonzeros;
-  (* Count the number of times each proof rule is used. *)
-  let rule_uses = Array.make 25 0 in
-  let f k p =
-    let i = code_of_proof p in
-    let n = Array.get rule_uses i + 1 in
-    Array.set rule_uses i n
-  in
-  iter_proofs f;
+  log "theorem most used: %d\n" !thm_uses_argmax
+;;
+
+let print_rule_uses() : unit =
   let total = float_of_int (nb_proofs()) in
   let part n = float_of_int (100 * n) /. total in
   let f i n = log "%10s %9d %2.f%%\n" (name_of_code i) n (part n) in
-  Array.iteri f rule_uses;
-  log "number of proof steps: %d\nnumber of unused theorems: %d (%2.f%%)\n"
-    (nb_proofs()) hist.(0) (part hist.(0))
+  Array.iteri f rule_uses
 ;;

--- a/xproof.ml
+++ b/xproof.ml
@@ -6,11 +6,55 @@ open Fusion
 open Xlib
 open Xprelude
 
+(*
 let the_proofs : proof array ref = ref [||]
 let proof_at k = Array.get (!the_proofs) k
 let the_proofs_idx : int ref = ref (-1)
 let nb_proofs() = !the_proofs_idx + 1
 let iter_proofs f = for k = 0 to !the_proofs_idx do f k (proof_at k) done
+*)
+
+let ic_dump : in_channel ref = ref stdin
+let pos_dump : int array ref = ref [||]
+
+let set_dump_file filename n =
+  let ic = open_in_bin filename in
+  ic_dump := ic;
+  pos_dump := Array.make n (-1)
+
+let nb_proofs() = Array.length !pos_dump
+
+let proof_at k =
+  let ic = !ic_dump in
+  let pos = !pos_dump in
+  let cur_pos = pos_in ic in
+  let p = Array.get pos k in
+  if p < 0 then
+    (* proof not yet read *)
+    begin
+      Array.set pos k cur_pos;
+      input_value ic
+    end
+  else
+    (* proof already read *)
+    begin
+      seek_in ic p;
+      let prf = input_value ic in
+      seek_in ic cur_pos;
+      prf
+    end
+
+let iter_proofs f =
+  let idx = ref 0 in
+  try
+    while !idx < Array.length !pos_dump do
+      let k = !idx in
+      f k (proof_at k);
+      idx := k + 1
+    done
+  with Failure _ as e ->
+    log "proof %d\n%!" !idx;
+    raise e
 
 (****************************************************************************)
 (* Print statistics on proofs. *)


### PR DESCRIPTION
- fix SPEC (some tactics rely on the failure of SPEC)
- fix variable name printing (in HOL-Light a term variable can have the same name as a type variable)