### PR TITLE
generate theorems as axioms for coq opam

### DIFF
--- a/xdk.ml
+++ b/xdk.ml
@@ -771,6 +771,15 @@ let export_theorems b map_thid_name =
         map_thid_name)
 ;;
 
+let export_theorems_as_axioms b map_thid_name =
+  export b "_opam"
+    (fun oc ->
+      out oc "\n(; named theorems ;)\n";
+      MapInt.iter
+        (fun k _ -> decl_theorem oc k (proof_at k) Axiom)
+        map_thid_name)
+;;
+
 let export_proofs_part b k x y =
   part := Some k;
   export b ("_part_" ^ string_of_int k)


### PR DESCRIPTION
- add command "hol2dk axm $file.lp" to generate $file_opam.lp
- update $file.mk targets lp, lpo, v, vo to produce the files $file_opam.*
- change format of dg file: put nb_parts first alone, and then the graph which we do not always need to read
- remove nb_parts argument from command "hol2dk thm"