### PR TITLE
change dump and mk-part commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           eval `opam env`
           hol2dk dg 3 xci
-          hol2dk mk-part xci
+          hol2dk mk xci
           export HOL2DK_DIR=.
           make -j 3 -f xci.mk dk
           dk check xci.dk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Dump proofs
         run: |
           eval `opam env`
-          cd hol-light; hol2dk dump ../xci.ml
+          cd hol-light; hol2dk dump-use ../xci.ml
       - name: Generate and check single-threaded dk output
         run: |
           eval `opam env`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+
+- add command dump-use for dumping a file without including "hol.ml"
+
+### Modified
+
+- rename mk-part command into mk
+- the dump command now includes "hol.ml"
+- do not print ocaml warnings while dumping proofs
+
 ## 0.0.0 (2023-11-08)
 
 First release.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,13 @@
 NOTES
 -----
 
+- dumping files after hol.ml:
+  * 100/bertrand: 2m13s 14M steps 4.8 Go
+  * 100/isoperimetric:
+
+- results on new computer with 32 * 13th Gen Intel(R) Core(TM) i9-13950HX:
+  * hol.ml dg 100 j 32: lp 48s v 39s vo 175m18s
+
 - instrumenting BETA_CONV reduces the number of proof steps of `hol.ml` by 0.1% only
 
 - instrumenting SYM reduces the number of proof steps of `hol.ml` by 4%

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Export HOL-Light proofs to Dedukti, Lambdapi and Coq
 ====================================================
 
-This project provides several programs:
+This project provides several things:
 - scripts `patch` and `unpatch` to (un)patch HOL-Light to dump proofs
-- a program `hol2dk` to generate Dedukti or Lambdapi files from dumped proofs
+- a program `hol2dk` with commands for dumping proofs from HOL-Light, translate those proofs to Dedukti and Lambdapi, and generate Makefile's to translation those proofs to Coq using lambdapi.
 
 [HOL-Light](https://github.com/jrh13/hol-light) is proof assistant
 based on higher-order logic, aka simple type theory.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 TODO
 ----
 
+- use a filename different from "dump.ml" and "dump.prf" to allow parallel dumping
+
 - create doc on readthedocs.io
 
 - replace terms of the form (@f _ x) by x if f is a function equal to


### PR DESCRIPTION
- rename mk-part command into mk
- rename dump command into dump-use
- add new command dump for dumping files coming after "hol.ml"
- do not print ocaml warnings while dumping proofs