### PR TITLE
do not export unused proof steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           eval `opam env`
           hol2dk pos xci
-	  hol2dk use xci
+          hol2dk use xci
           hol2dk xci.dk
           dk check xci.dk
       - name: Generate and check single-threaded lp output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,12 +53,12 @@ jobs:
         run: |
           eval `opam env`
           hol2dk pos xci
+	  hol2dk use xci
           hol2dk xci.dk
           dk check xci.dk
       - name: Generate and check single-threaded lp output
         run: |
           eval `opam env`
-          hol2dk pos xci
           hol2dk xci.lp
           lambdapi check xci.lp
       - name: Generate and check multi-threaded dk output

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - rename mk-part command into mk
 - the dump command now includes "hol.ml"
 - do not print ocaml warnings while dumping proofs
+- do not export unused proofs (about 7%)
+
+### Fixed
+
+- output of hol2dk axm
+- README.md
 
 ## 0.0.0 (2023-11-08)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- output of hol2dk axm
 - README.md
+- output of hol2dk axm
+- output of hol2dk mk
 
 ## 0.0.0 (2023-11-08)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - the dump command now includes "hol.ml"
 - do not print ocaml warnings while dumping proofs
 - do not export unused proofs (about 7%)
+- make hol2dk stat give the number of unused proofs
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -329,17 +329,17 @@ Multi-threaded translation to Lambdapi with `dg 100`:
   * lp files size: 1.9 Go
   * type abbrevs: 1.3 Mo
   * term abbrevs: 665 Mo
-  * verification by lambdapi with 64 Go RAM: 4h10
+  * verification by lambdapi: 4h10
   * translation to Coq: 30s 1.8 Go
-  * verification by Coq with 64 Go RAM: 6h
+  * verification by Coq: 6h
 
 Multi-threaded translation to Dedukti with `dg 100`:
-  * dk file generation time: 1m57s
-  * dk file size: 3 Go
+  * dk file generation time: 1m9s
+  * dk file size: 2.8 Go
   * type abbrevs: 1.3 Mo
-  * term abbrevs: 772 Mo
-  * kocheck with 32 Go RAM: 12m52s
-  * dkcheck with 64 Go RAM: 14m05s
+  * term abbrevs: 752 Mo
+  * kocheck: 6m19s
+  * dkcheck: 6m22s
 
 Results for `hol.ml` up to `arith.ml` (by commenting from `loads "wf.ml"` to the end) with `dg 7`:
   * proof dumping time: 12s 77 Mo

--- a/README.md
+++ b/README.md
@@ -294,8 +294,9 @@ Results
 Dumping of `hol.ml`:
   * checking time without proof dumping: 1m14s
   * checking time with proof dumping: 1m44s (+40%)
-  * dumped files size: 3.1 Go
-  * number of proof steps: 8.9 M (2834 theorems)
+  * dumped files size: 3 Go
+  * number of named theorems: 2834
+  * number of proof steps: 8.5 M (8% unused) 
 
 | rule       |  % |
 |:-----------|---:|
@@ -309,6 +310,26 @@ Dumping of `hol.ml`:
 | abs        |  2 |
 | spec       |  2 |
 
+Results on a machine with 32 processors i9-13950HX and 64 Go RAM:
+
+Multi-threaded translation to Lambdapi with `dg 100`:
+  * hol2dk dg: 14s
+  * lp files generation time: 41s
+  * lp files size: 1.9 Go
+  * type abbrevs: 1.3 Mo
+  * term abbrevs: 665 Mo (35%)
+  * verification by lambdapi: 4h10
+  * translation to Coq: 30s 1.8 Go
+  * verification by Coq: 2h29
+
+Multi-threaded translation to Dedukti with `dg 100`:
+  * dk file generation time: 1m9s
+  * dk file size: 2.8 Go
+  * type abbrevs: 1.3 Mo
+  * term abbrevs: 752 Mo (27%)
+  * kocheck: 6m19s
+  * dkcheck: 6m22s
+
 Single-threaded translation to Lambdapi (data of 12 March 2023):
   * lp files generation time: 12m8s
   * lp files size: 2.5 Go
@@ -320,26 +341,6 @@ Single-threaded translation to Dedukti (data of 12 March 2023):
   * dk files size: 3.6 Go
   * type abbreviations: 524 Ko
   * term abbreviations: 820 Mo (23%)
-
-Results on a machine with 32 processors i9-13950HX and 64 Go RAM:
-
-Multi-threaded translation to Lambdapi with `dg 100`:
-  * hol2dk dg: 14s
-  * lp files generation time: 41s
-  * lp files size: 1.9 Go
-  * type abbrevs: 1.3 Mo
-  * term abbrevs: 665 Mo
-  * verification by lambdapi: 4h10
-  * translation to Coq: 30s 1.8 Go
-  * verification by Coq: 2h29
-
-Multi-threaded translation to Dedukti with `dg 100`:
-  * dk file generation time: 1m9s
-  * dk file size: 2.8 Go
-  * type abbrevs: 1.3 Mo
-  * term abbrevs: 752 Mo
-  * kocheck: 6m19s
-  * dkcheck: 6m22s
 
 Results for `hol.ml` up to `arith.ml` (by commenting from `loads "wf.ml"` to the end) with `dg 7`:
   * proof dumping time: 12s 77 Mo

--- a/README.md
+++ b/README.md
@@ -324,13 +324,13 @@ Single-threaded translation to Dedukti (data of 12 March 2023):
 Results on a machine with 32 processors i9-13950HX and 64 Go RAM:
 
 Multi-threaded translation to Lambdapi with `dg 100`:
-  * hol2dk dg: 15s
-  * lp files generation time: 1m5s
-  * lp files size: 2.1 Go
+  * hol2dk dg: 14s
+  * lp files generation time: 41s
+  * lp files size: 1.9 Go
   * type abbrevs: 1.3 Mo
-  * term abbrevs: 681 Mo
+  * term abbrevs: 665 Mo
   * verification by lambdapi with 64 Go RAM: 4h10
-  * translation to Coq: 50s 1.9 Go
+  * translation to Coq: 30s 1.8 Go
   * verification by Coq with 64 Go RAM: 6h
 
 Multi-threaded translation to Dedukti with `dg 100`:

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Multi-threaded translation to Lambdapi with `dg 100`:
   * lp files size: 1.9 Go
   * type abbrevs: 1.3 Mo
   * term abbrevs: 665 Mo (35%)
-  * verification by lambdapi: 4h10
+  * verification by lambdapi: 4h10 on 28 processors Intel Core Haswell @ 2.3 GHz with 16 Mo cache
   * translation to Coq: 30s 1.8 Go
   * verification by Coq: 2h29
 

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Multi-threaded translation to Lambdapi with `dg 100`:
   * term abbrevs: 665 Mo
   * verification by lambdapi: 4h10
   * translation to Coq: 30s 1.8 Go
-  * verification by Coq: 6h
+  * verification by Coq: 2h29
 
 Multi-threaded translation to Dedukti with `dg 100`:
   * dk file generation time: 1m9s

--- a/README.md
+++ b/README.md
@@ -309,19 +309,21 @@ Dumping of `hol.ml`:
 | abs        |  2 |
 | spec       |  2 |
 
-Single-threaded translation to Lambdapi:
+Single-threaded translation to Lambdapi (data of 12 March 2023):
   * lp files generation time: 12m8s
   * lp files size: 2.5 Go
   * type abbreviations: 460 Ko
   * term abbreviations: 787 Mo (31%)
 
-Single-threaded translation to Dedukti:
+Single-threaded translation to Dedukti (data of 12 March 2023):
   * dk files generation time: 22m37s
   * dk files size: 3.6 Go
   * type abbreviations: 524 Ko
   * term abbreviations: 820 Mo (23%)
 
-Multi-threaded translation to Lambdapi with `mk 100` and `-j 28`:
+Results on a machine with 32 processors i9-13950HX and 64 Go RAM:
+
+Multi-threaded translation to Lambdapi with `dg 100`:
   * hol2dk dg: 15s
   * lp files generation time: 1m5s
   * lp files size: 2.1 Go
@@ -331,7 +333,7 @@ Multi-threaded translation to Lambdapi with `mk 100` and `-j 28`:
   * translation to Coq: 50s 1.9 Go
   * verification by Coq with 64 Go RAM: 6h
 
-Multi-threaded translation to Dedukti with `mk 100`:
+Multi-threaded translation to Dedukti with `dg 100`:
   * dk file generation time: 1m57s
   * dk file size: 3 Go
   * type abbrevs: 1.3 Mo
@@ -339,15 +341,15 @@ Multi-threaded translation to Dedukti with `mk 100`:
   * kocheck with 32 Go RAM: 12m52s
   * dkcheck with 64 Go RAM: 14m05s
 
-Results for `hol.ml` up to `arith.ml` (by commenting from `loads "wf.ml"` to the end) with `mk 7` and `-j 7` :
+Results for `hol.ml` up to `arith.ml` (by commenting from `loads "wf.ml"` to the end) with `dg 7`:
   * proof dumping time: 12s 77 Mo
-  * number of proof steps: 302 K
-  * dk file generation: 6s 76 Mo
-  * checking time with dk check: 13s
-  * lp file generation: 4s 52 Mo
-  * checking time with lambdapi: 1m22s (1m30s with `-c`)
-  * translation to Coq: 2.8s 52 Mo
-  * checking time for Coq 8.18.0: 4m34s
+  * number of proof steps: 302 K (10% unused)
+  * dk file generation: 3s 69 Mo
+  * checking time with dk check: 9s
+  * lp file generation: 2s 47 Mo
+  * checking time with lambdapi: 1m15s
+  * translation to Coq: 1s 45 Mo
+  * checking time for Coq 8.18.0: 3m12s
 
 Exporting pure Q0 proofs
 ------------------------

--- a/main.ml
+++ b/main.ml
@@ -402,18 +402,18 @@ dump_map_thid_name "%s.thm" %a;;
      exit 0
 
   | ["use";basename] ->
-     (* The .use file records an array uses such that uses[i] = 0 if
-        i is a named theorem, the highest theorem index j>i using i if
-        there is one, and -1 otherwise. *)
+     (* The .use file records an array last_use such that last_use[i]
+        = 0 if i is a named theorem, the highest theorem index j using
+        i if there is one, and -1 otherwise. *)
      let nb_proofs = read_nb_proofs basename in
-     let uses = Array.make nb_proofs (-1) in
+     let last_use = Array.make nb_proofs (-1) in
      read_prf basename
-       (fun idx p -> List.iter (fun k -> Array.set uses k idx) (deps p));
-     MapInt.iter (fun k _ -> Array.set uses k 0) (read_thm basename);
+       (fun idx p -> List.iter (fun k -> Array.set last_use k idx) (deps p));
+     MapInt.iter (fun k _ -> Array.set last_use k 0) (read_thm basename);
      let dump_file = basename ^ ".use" in
      log "generate %s ...\n" dump_file;
      let oc = open_out_bin dump_file in
-     output_value oc uses;
+     output_value oc last_use;
      close_out oc;
      exit 0
 
@@ -510,6 +510,7 @@ dump_map_thid_name "%s.thm" %a;;
      read_pos basename;
      init_proof_reading basename;
      cur_part_max := (k * nb_proofs) / nb_parts;
+     read_use basename;
      if is_dk f then
        begin
          Xdk.export_proofs_part basename k x y;
@@ -519,7 +520,6 @@ dump_map_thid_name "%s.thm" %a;;
        end
      else
        begin
-         read_use basename;
          let dg = input_value ic in
          Xlp.export_proofs_part basename dg k x y;
          let suffix = "_part_" ^ string_of_int k in

--- a/main.ml
+++ b/main.ml
@@ -237,8 +237,8 @@ let make b =
       done;
       out oc "\n"
     done;
-    out oc "%s_opam.%so: coq.%so theory_hol.%so %s_types.%so %s_terms.%so \
-            %s_axioms.%so\n" b e e e b e b e b e;
+    out oc "%s_opam.%so: theory_hol.%so %s_types.%so %s_terms.%so \
+            %s_axioms.%so\n" b e e b e b e b e;
     out oc "%%.%so: %%.%s\n\t%s $<\n" e e c;
     out oc
       ".PHONY: clean-%so\nclean-%so:\n\trm -f theory_hol.%so %s*.%so%a\n"

--- a/main.ml
+++ b/main.ml
@@ -534,6 +534,7 @@ dump_map_thid_name "%s.thm" %a;;
      read_sig basename;
      read_pos basename;
      init_proof_reading basename;
+     read_use basename;
      Xlp.export_one_file_by_prf basename x y
 
   | ["mk-lp";nb_parts;basename] ->
@@ -570,6 +571,7 @@ dump_map_thid_name "%s.thm" %a;;
        end;
      read_pos basename;
      init_proof_reading basename;
+     read_use basename;
      if dk then
        begin
          Xdk.export_proofs basename r;

--- a/xdk.ml
+++ b/xdk.ml
@@ -629,15 +629,22 @@ let theorem oc k p = decl_theorem oc k p Unnamed_thm;;
    [k] as an axiom. *)
 let theorem_as_axiom oc k p = decl_theorem oc k p Axiom;;
 
+(* [proofs_in_interval oc x y] outputs on [oc] the proofs in interval
+   [x] .. [y]. *)
+let proofs_in_interval oc x y =
+  for k = x to y do
+    if Array.get !Xproof.last_use k >= 0 then theorem oc k (proof_at k)
+  done
+
 (* [proofs_in_range oc r] outputs on [oc] the theorems in range [r]. *)
 let proofs_in_range oc = function
   | Only x ->
      let p = proof_at x in
      List.iter (fun k -> theorem_as_axiom oc k (proof_at k)) (deps p);
      theorem oc x p
-  | Upto y -> for k = 0 to y do theorem oc k (proof_at k) done
   | All -> iter_proofs_at (theorem oc)
-  | Inter(x,y) -> for k = x to y do theorem oc k (proof_at k) done
+  | Upto y -> proofs_in_interval oc 0 y
+  | Inter(x,y) -> proofs_in_interval oc x y
 ;;
 
 (****************************************************************************)

--- a/xlib.ml
+++ b/xlib.ml
@@ -497,8 +497,12 @@ let count_thm (uses : int array) (p : proof) : unit =
    are used i times, for each i from 0 to the maximum of [uses]. *)
 let print_histogram (uses : int array) : unit =
   (* compute max and argmax *)
-  let max = ref (-1) and argmax = ref (-1) in
-  Array.iteri (fun k n -> if n > !max then (max := n; argmax := k)) uses;
+  let max = ref (-1) and argmax = ref (-1) and unused = ref (-1) in
+  let f k n =
+    if n > !max then (max := n; argmax := k);
+    if n = 0 then unused := k
+  in
+  Array.iteri f  uses;
   let hist = Array.make (!max + 1) 0 in
   Array.iter (fun n -> Array.set hist n (Array.get hist n + 1)) uses;
   log "(* \"i: n\" means that n proofs are used i times *)\n";
@@ -506,7 +510,10 @@ let print_histogram (uses : int array) : unit =
   Array.iteri
     (fun i n -> if n > 0 then (incr nonzeros; log "%d: %d\n" i n)) hist;
   log "number of mappings: %d\n" !nonzeros;
-  log "most used theorem: %d\n" !argmax
+  log "most used theorem: %d\n" !argmax;
+  log "unused theorems: %d (%d%%)\n"
+    hist.(0) ((100 * hist.(0)) / Array.length uses);
+  log "last unused theorem: %d\n" !unused
 ;;
 
 (* [count_rule uses p] updates [uses] with the rule of [p]. *)

--- a/xlp.ml
+++ b/xlp.ml
@@ -481,9 +481,8 @@ let decl_theorem oc k p d =
      let decl_hyps oc ts =
        List.iteri (fun i t -> out oc " (h%d : Prf %a)" (i+1) term t) ts in
      let prv =
-       Array.length !Xproof.thm_uses > 0 &&
-       let l = Array.get !Xproof.thm_uses k in
-       l = -1 || (l > 0 && l < !cur_part_max)
+       let l = Array.get !Xproof.last_use k in
+       l > 0 && l < !cur_part_max
      in
      out oc "%s symbol thm_%d%a%a%a : Prf %a ≔ %a;\n"
        (if prv then "private" else "opaque") k
@@ -518,6 +517,13 @@ let theorem oc k p = decl_theorem oc k p Unnamed_thm;;
    [k] as an axiom. *)
 let theorem_as_axiom oc k p = decl_theorem oc k p Axiom;;
 
+(* [proofs_in_interval oc x y] outputs on [oc] the proofs in interval
+   [x] .. [y]. *)
+let proofs_in_interval oc x y =
+  for k = x to y do
+    if Array.get !Xproof.last_use k >= 0 then theorem oc k (proof_at k)
+  done
+
 (* [proofs_in_range oc r] outputs on [oc] the proofs in range [r]. *)
 let proofs_in_range oc = function
   | Only x ->
@@ -528,9 +534,9 @@ let proofs_in_range oc = function
 "flag \"print_implicits\" on;
 flag \"print_domains\" on;
 print thm_%d;\n" x*)
-  | Upto y -> for k = 0 to y do theorem oc k (proof_at k) done
   | All -> iter_proofs_at (theorem oc)
-  | Inter(x,y) -> for k = x to y do theorem oc k (proof_at k) done
+  | Upto y -> proofs_in_interval oc 0 y
+  | Inter(x,y) -> proofs_in_interval oc x y
 ;;
 
 (****************************************************************************)
@@ -628,7 +634,7 @@ let export_proofs_part =
       for i = 1 to k-1 do
         if dg.(k-1).(i-1) > 0 then require oc b ("_part_" ^ string_of_int i)
       done;
-      proofs_in_range oc (Inter(x,y)))
+      proofs_in_interval oc x y)
 ;;
 
 let export_theorems_part k b map_thid_name =

--- a/xlp.ml
+++ b/xlp.ml
@@ -686,7 +686,9 @@ require open hol-light.theory_hol;\n
     theorem oc k p;
     close_out oc
   in
-  for k = x to y do theorem_file k (proof_at k) done
+  for k = x to y do
+    if Array.get !Xproof.last_use k >= 0 then theorem_file k (proof_at k)
+  done
 ;;
 
 (* [gen_lp_makefile_one_file_by_prf basename nb_proofs nb_parts] creates

--- a/xlp.ml
+++ b/xlp.ml
@@ -506,7 +506,7 @@ let decl_theorem oc k p d =
      let term = unabbrev_term rmap in
      let decl_hyps oc ts =
        List.iteri (fun i t -> out oc " (h%d : Prf %a)" (i+1) term t) ts in
-     out oc "opaque symbol thm_%s%a%a%a : Prf %a;\n" n
+     out oc "symbol thm_%s%a%a%a : Prf %a;\n" n
        typ_vars tvs (list (unabbrev_decl_param rmap)) xs decl_hyps ts term t
 ;;
 

--- a/xproof.ml
+++ b/xproof.ml
@@ -43,8 +43,17 @@ let proof_at k =
   input_value ic
 ;;
 
+(* [!last_use.(i) = 0] if i is a named theorem, the highest theorem
+   index j using i if there is one, and -1 otherwise. *)
+let last_use : int array ref = ref [||];;
+
+let read_use basename = last_use := read_val (basename ^ ".use");;
+
+(* [!cur_part_max] indicates the maximal index of the current part. *)
+let cur_part_max : int ref = ref (-1);;
+
 (* [iter_proofs f] runs [f k (proof_at k)] on all proof index [k] from
-   0 to [nb_proofs() - 1]. Can be used after [read_pos] and
+   0 to [nb_proofs() - 1]. Can be used after [read_pos], [read_use] and
    [init_proof_reading] only. *)
 let iter_proofs_at (f : int -> proof -> unit) =
   let idx = ref 0 in
@@ -52,16 +61,10 @@ let iter_proofs_at (f : int -> proof -> unit) =
   try
     while !idx < n do
       let k = !idx in
-      f k (proof_at k);
+      if Array.get !last_use k >= 0 then f k (proof_at k);
       idx := k + 1
     done
   with Failure _ as e ->
     log "proof %d\n%!" !idx;
     raise e
 ;;
-
-let thm_uses : int array ref = ref [||];;
-
-let read_use basename = thm_uses := read_val (basename ^ ".use");;
-
-let cur_part_max : int ref = ref (-1);;


### PR DESCRIPTION
- do not export unused proofs (about 7%)
- make hol2dk stat give the number of unused proofs
- fix output of hol2dk axm
- fix output of hol2dk mk