### PR TITLE
add command simp to simplify proof files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Generate and check single-threaded dk output
         run: |
           eval `opam env`
+	  hol2dk simp xci
           hol2dk pos xci
           hol2dk use xci
           hol2dk xci.dk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate and check single-threaded dk output
         run: |
           eval `opam env`
-	  hol2dk simp xci
+          hol2dk simp xci
           hol2dk pos xci
           hol2dk use xci
           hol2dk xci.dk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Dump proofs
         run: |
           eval `opam env`
-          cd hol-light; hol2dk dump-use ../xci.ml
+          cd hol-light; hol2dk dump-use ../xci.ml; cd ..
           hol2dk pos xci
           hol2dk use xci
           hol2dk simp xci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,12 @@ jobs:
         run: |
           eval `opam env`
           cd hol-light; hol2dk dump-use ../xci.ml
+          hol2dk pos xci
+          hol2dk use xci
+          hol2dk simp xci
       - name: Generate and check single-threaded dk output
         run: |
           eval `opam env`
-          hol2dk simp xci
-          hol2dk pos xci
-          hol2dk use xci
           hol2dk xci.dk
           dk check xci.dk
       - name: Generate and check single-threaded lp output

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - add-links script
+- command hol2dk simp to simplify prf files
 
 ## 0.0.1 (2023-11-22)
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cd $HOLLIGHT_DIR
 hol2dk dump file.ml
 ```
 
-This will generate the files `file.sig`, `file.prf` and `file.thm`.
+This will generate the files `file.sig`, `file-origin.prf` and `file.thm`.
 
 WARNING: it is important to run `hol2dk dump` in the HOL-Light directory so as to compute the list of named theorems properly.
 
@@ -141,7 +141,7 @@ Simplifying dumped proofs
 
 HOL-Light proofs are often overly complicated and can be simplified following simple rewrite rules. For instance, s(u)=s(u) can be derived by MK_COMB from s=s and u=u, while it can be directly proved by REFL.
 
-To generate a simplified proof file do:
+To generate a simplified proof file `file.prf` from `file-origin.prf` do:
 ```
 hol2dk simp file
 ```
@@ -359,7 +359,7 @@ Multi-threaded translation to Dedukti with `dg 100`:
   * type abbrevs: 1.2 Mo
   * term abbrevs: 737 Mo (32%)
   * kocheck: 6m19s
-  * dkcheck: 6m22s
+  * dkcheck: 5m23s
 
 Single-threaded translation to Lambdapi (data of 12 March 2023):
   * lp files generation time: 12m8s

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cd $HOLLIGHT_DIR
 hol2dk dump file.ml
 ```
 
-This will generate the files `file.sig`, `file-origin.prf` and `file.thm`.
+This will generate the files `file.sig`, `file.prf` and `file.thm`.
 
 WARNING: it is important to run `hol2dk dump` in the HOL-Light directory so as to compute the list of named theorems properly.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Simplification rules currently implemented:
 - CONJUNCT2(CONJ(_,p)) --> p
 - MKCOMB(REFL(t),REFL(u)) --> REFL(t(u))
 
-To generate a simplified proof file `file.prf` from `file-origin.prf` do:
+To simplify `file.prf` and recompute `file.pos` and `file.use` do:
 ```
 hol2dk simp file
 ```
@@ -391,7 +391,7 @@ Results for `hol.ml` up to `arith.ml` (by commenting from `loads "wf.ml"` to the
   * lp file generation: 1s 38 Mo
   * checking time with lambdapi: 61s
   * translation to Coq: 1s 36 Mo
-  * checking time for Coq 8.18.0: 3m12s
+  * checking time for Coq 8.18.0: 2m4s
 
 Exporting pure Q0 proofs
 ------------------------

--- a/README.md
+++ b/README.md
@@ -333,10 +333,10 @@ Dumping of `hol.ml`:
   * checking time with proof dumping: 1m44s (+40%)
   * dumped files size: 3 Go
   * number of named theorems: 2842
-  * number of proof steps: 8.5 M (8% useless)
+  * number of proof steps: 8.5 M (8% unused)
   * simplification time: 1m18s
-  * number of simplifications: 1.2 M
-  * useless proof steps after simplification: 28% 
+  * number of simplifications: 462 K (5%)
+  * unused proof steps after simplification: 19% 
 
 | rule       |  % |
 |:-----------|---:|
@@ -358,7 +358,7 @@ Multi-threaded translation to Lambdapi with `dg 100`:
   * lp files size: 1.6 Go
   * type abbrevs: 1.1 Mo
   * term abbrevs: 652 Mo (40%)
-  * verification by lambdapi: 4h10 on 28 processors Intel Core Haswell @ 2.3 GHz with 16 Mo cache
+  * verification by lambdapi: fails (too big for lambdapi)
   * translation to Coq: 28s 1.5 Go
   * verification by Coq: 1h52
 
@@ -384,8 +384,9 @@ Single-threaded translation to Dedukti (data of 12 March 2023):
 
 Results for `hol.ml` up to `arith.ml` (by commenting from `loads "wf.ml"` to the end) with `dg 7`:
   * proof dumping time: 11s 77 Mo (448 named theorems)
-  * number of proof steps: 302 K (9% useless)
-  * prf simplification: 2s 79 Mo (32% useless)
+  * number of proof steps: 302 K (9% unused)
+  * prf simplification: 2s
+  * unused proofs after simplification: 20%
   * dk file generation: 2s 55 Mo
   * checking time with dk check: 7s
   * lp file generation: 1s 38 Mo

--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ hol2dk dump-use file.ml
 ```
 where `file.ml` should at least contain the contents of `hol.ml` until the line `loads "fusion.ml";;`.
 
+Once you have generate `file.prf`, you need to generate the files `file.pos` and `file.use` with:
+```
+hol2dk pos file
+hol2dk use file
+```
+
+`file.pos` contains the position in `file.prf` of each proof step.
+
+`file.use` contains data to know whether a proof step is actually useful and needs to be translated. Indeed, since HOL-Light tactics may fail, some proof steps are generated but are not used in the end. Therefore, they do not need to be translated.
+
 Simplifying dumped proofs
 -------------------------
 
@@ -160,16 +170,6 @@ Generating dk/lp files from dumped files
 
 The base theory in which HOL-Light proofs are translated is described in the files [theory_hol.lp](https://github.com/Deducteam/hol2dk/blob/main/theory_hol.lp) and [theory_hol.dk](https://github.com/Deducteam/hol2dk/blob/main/theory_hol.dk).
 
-You first need to generate `file.pos` and `file.use` with:
-```
-hol2dk pos file
-hol2dk use file
-```
-`file.pos` contains the position in `file.prf` of each proof step for fast access.
-
-`file.use` contains data to know whether a proof step is actually useful and needs to be translated. Indeed, since HOL-Light tactics may fail, some proof steps are generated but are not used in the end.
-
-Since HOL-Light tactics may fail, some proof steps may be useless.
 
 You can then generate `file.dk` with:
 ```

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Summary of hol2dk commands
 
 Get it by running `hol2dk` without arguments.
 
-Dumping HOL-Light proofs
-------------------------
+Dumping HOL-Light proof steps
+-----------------------------
 
 For dumping a HOL-Light file depending on `hol.ml` do:
 ```
@@ -136,6 +136,16 @@ hol2dk dump-use file.ml
 ```
 where `file.ml` should at least contain the contents of `hol.ml` until the line `loads "fusion.ml";;`.
 
+Simplifying dumped proofs
+-------------------------
+
+HOL-Light proofs are often overly complicated and can be simplified following simple rewrite rules. For instance, s(u)=s(u) can be derived by MK_COMB from s=s and u=u, while it can be directly proved by REFL.
+
+To generate a simplified proof file do:
+```
+hol2dk simp file
+```
+
 Generating dk/lp files from dumped files
 --------------------------------------
 
@@ -146,6 +156,11 @@ You first need to generate `file.pos` and `file.use` with:
 hol2dk pos file
 hol2dk use file
 ```
+`file.pos` contains the position in `file.prf` of each proof step for fast access.
+
+`file.use` contains data to know whether a proof step is actually useful and needs to be translated. Indeed, since HOL-Light tactics may fail, some proof steps are generated but are not used in the end.
+
+Since HOL-Light tactics may fail, some proof steps may be useless.
 
 You can then generate `file.dk` with:
 ```
@@ -309,37 +324,40 @@ Dumping of `hol.ml`:
   * checking time with proof dumping: 1m44s (+40%)
   * dumped files size: 3 Go
   * number of named theorems: 2842
-  * number of proof steps: 8.5 M (8% unused) 
+  * number of proof steps: 8.5 M (8% useless)
+  * simplification time: 1m18s
+  * number of simplifications: 1.2 M
+  * useless proof steps after simplification: 28% 
 
 | rule       |  % |
 |:-----------|---:|
-| refl       | 29 |
-| eqmp       | 19 |
-| comb       | 17 |
-| term_subst | 12 |
-| trans      |  6 |
-| type_subst |  3 |
-| beta       |  3 |
-| abs        |  2 |
-| spec       |  2 |
+| `refl`       | 32 |
+| `eqmp`       | 14 |
+| `comb`       | 12 |
+| `term_subst` | 9 |
+| `trans`      |  5 |
+| `type_subst` |  3 |
+| `beta`       |  4 |
+| `abs`        |  2 |
+| `spec`       |  2 |
 
 Results on a machine with 32 processors i9-13950HX and 64 Go RAM:
 
 Multi-threaded translation to Lambdapi with `dg 100`:
   * hol2dk dg: 14s
-  * lp files generation time: 41s
-  * lp files size: 1.9 Go
-  * type abbrevs: 1.3 Mo
-  * term abbrevs: 665 Mo (35%)
+  * lp files generation time: 36s
+  * lp files size: 1.6 Go
+  * type abbrevs: 1.1 Mo
+  * term abbrevs: 652 Mo (40%)
   * verification by lambdapi: 4h10 on 28 processors Intel Core Haswell @ 2.3 GHz with 16 Mo cache
-  * translation to Coq: 30s 1.8 Go
+  * translation to Coq: 28s 1.5 Go
   * verification by Coq: 2h29
 
 Multi-threaded translation to Dedukti with `dg 100`:
-  * dk file generation time: 1m9s
-  * dk file size: 2.8 Go
-  * type abbrevs: 1.3 Mo
-  * term abbrevs: 752 Mo (27%)
+  * dk file generation time: 1m7s
+  * dk file size: 2.3 Go
+  * type abbrevs: 1.2 Mo
+  * term abbrevs: 737 Mo (32%)
   * kocheck: 6m19s
   * dkcheck: 6m22s
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Dumping of `hol.ml`:
   * checking time without proof dumping: 1m14s
   * checking time with proof dumping: 1m44s (+40%)
   * dumped files size: 3 Go
-  * number of named theorems: 2834
+  * number of named theorems: 2842
   * number of proof steps: 8.5 M (8% unused) 
 
 | rule       |  % |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This will generate the files `file.sig`, `file.prf` and `file.thm`.
 
 WARNING: it is important to run `hol2dk dump` in the HOL-Light directory so as to compute the list of named theorems properly.
 
-For dumping a subset of `hol.ml` do:
+For dumping (a subset of) `hol.ml` do:
 ```
 cd $HOLLIGHT_DIR
 hol2dk dump-use file.ml

--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ Simplifying dumped proofs
 
 HOL-Light proofs are often overly complicated and can be simplified following simple rewrite rules. For instance, s(u)=s(u) can be derived by MK_COMB from s=s and u=u, while it can be directly proved by REFL.
 
+Simplification rules currently implemented:
+- SYM(REFL(t)) --> REFL(t)
+- SYM(SYM(p)) --> p
+- TRANS(REFL(t),p) --> p
+- TRANS(p,REFL(t)) --> p
+- CONJUNCT1(CONJ(p,_)) --> p
+- CONJUNCT2(CONJ(_,p)) --> p
+- MKCOMB(REFL(t),REFL(u)) --> REFL(t(u))
+
 To generate a simplified proof file `file.prf` from `file-origin.prf` do:
 ```
 hol2dk simp file
@@ -351,15 +360,15 @@ Multi-threaded translation to Lambdapi with `dg 100`:
   * term abbrevs: 652 Mo (40%)
   * verification by lambdapi: 4h10 on 28 processors Intel Core Haswell @ 2.3 GHz with 16 Mo cache
   * translation to Coq: 28s 1.5 Go
-  * verification by Coq: 2h29
+  * verification by Coq: 1h52
 
 Multi-threaded translation to Dedukti with `dg 100`:
   * dk file generation time: 1m7s
   * dk file size: 2.3 Go
   * type abbrevs: 1.2 Mo
   * term abbrevs: 737 Mo (32%)
-  * kocheck: 6m19s
   * dkcheck: 5m23s
+  * kocheck: 5m54s
 
 Single-threaded translation to Lambdapi (data of 12 March 2023):
   * lp files generation time: 12m8s
@@ -374,13 +383,14 @@ Single-threaded translation to Dedukti (data of 12 March 2023):
   * term abbreviations: 820 Mo (23%)
 
 Results for `hol.ml` up to `arith.ml` (by commenting from `loads "wf.ml"` to the end) with `dg 7`:
-  * proof dumping time: 12s 77 Mo
-  * number of proof steps: 302 K (10% unused)
-  * dk file generation: 3s 69 Mo
-  * checking time with dk check: 9s
-  * lp file generation: 2s 47 Mo
-  * checking time with lambdapi: 1m15s
-  * translation to Coq: 1s 45 Mo
+  * proof dumping time: 11s 77 Mo (448 named theorems)
+  * number of proof steps: 302 K (9% useless)
+  * prf simplification: 2s 79 Mo (32% useless)
+  * dk file generation: 2s 55 Mo
+  * checking time with dk check: 7s
+  * lp file generation: 1s 38 Mo
+  * checking time with lambdapi: 61s
+  * translation to Coq: 1s 36 Mo
   * checking time for Coq 8.18.0: 3m12s
 
 Exporting pure Q0 proofs

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 TODO
 ----
 
+- put nb_proofs in a separate file
+
 - add commands for patch/unpatch/add-links ?
 
 - use a filename different from "dump.ml" and "dump.prf" to allow parallel dumping
@@ -20,7 +22,7 @@ TODO
     sym (refl x) --> refl x
     sym (sym p) --> p
     trans (sym p) (sym q) --> or <-- sym (trans q p) ?
-    
+	  
 - add v file checking in ci
 
 - instrument excluded middle in class.ml

--- a/TODO.md
+++ b/TODO.md
@@ -14,15 +14,6 @@ TODO
 
 - replace type variables like _1718 by better names like A
 
-- turn proof_content into a private data type so as to simplify proofs
-  on the fly with the following rules:
-
-    trans p (refl _) --> p
-    trans (refl _) p --> p
-    sym (refl x) --> refl x
-    sym (sym p) --> p
-    trans (sym p) (sym q) --> or <-- sym (trans q p) ?
-	  
 - add v file checking in ci
 
 - instrument excluded middle in class.ml

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 TODO
 ----
 
+- compute useful theorems from named theorems and remove useless theorems
+
 - put nb_proofs in a separate file
 
 - add commands for patch/unpatch/add-links ?

--- a/add-links
+++ b/add-links
@@ -19,13 +19,14 @@ then
     exit 1
 fi
 
-mkdir -p $1
-cd $1
 for ext in prf sig thm pos use
 do
    ln -f -s $HOLLIGHT_DIR/$1.$ext
 done
+
 for f in theory_hol.dk theory_hol.lp lambdapi.pkg coq.v  _CoqProject
 do
     ln -f -s $HOL2DK_DIR/$f
 done
+
+ln -f -s $1.mk Makefile

--- a/fusion.ml
+++ b/fusion.ml
@@ -107,7 +107,7 @@ module type Hol_kernel =
       val hyp : thm -> term list
       val concl : thm -> term
       val index_of : thm -> int
-(*REMOVE
+      (*REMOVE
       val REFL : term -> thm
       val TRANS : thm -> thm -> thm
       val MK_COMB : thm * thm -> thm
@@ -137,10 +137,10 @@ module type Hol_kernel =
       val SYM : thm -> thm
       val BETA_CONV : term -> thm
       (*END_ND*)
-REMOVE*)
+
       val new_theorem : term list -> term -> proof_content -> thm
       val dump_signature : string -> unit
-
+      REMOVE*)
       val axioms : unit -> thm list
       val new_axiom : term -> thm
       val definitions : unit -> thm list

--- a/fusion.ml
+++ b/fusion.ml
@@ -54,7 +54,7 @@ module type Hol_kernel =
       | Pdisj_cases of int * int * int
       | Psym of int
 
-      type proof = private Proof of (thm * proof_content)
+      type proof = Proof of (thm * proof_content)
 
       val types: unit -> (string * int)list
       val get_type_arity : string -> int
@@ -107,7 +107,7 @@ module type Hol_kernel =
       val hyp : thm -> term list
       val concl : thm -> term
       val index_of : thm -> int
-      (*REMOVE
+(*REMOVE
       val REFL : term -> thm
       val TRANS : thm -> thm -> thm
       val MK_COMB : thm * thm -> thm
@@ -137,24 +137,22 @@ module type Hol_kernel =
       val SYM : thm -> thm
       val BETA_CONV : term -> thm
       (*END_ND*)
-
+REMOVE*)
       val new_theorem : term list -> term -> proof_content -> thm
       val dump_signature : string -> unit
-      REMOVE*)
+
       val axioms : unit -> thm list
-      (*REMOVE
       val new_axiom : term -> thm
-      REMOVE*)
       val definitions : unit -> thm list
-      (*REMOVE
       val new_basic_definition : term -> thm
       val new_basic_type_definition :
               string -> string * string -> thm -> thm * thm
-      REMOVE*)
+
       (*REMOVE*)val the_type_constants : (string * int) list ref
       (*REMOVE*)val the_term_constants : (string * hol_type) list ref
       (*REMOVE*)val the_axioms : thm list ref
       (*REMOVE*)val the_definitions : thm list ref
+      (*REMOVE*)val change_proof_content : proof -> proof_content -> proof
 end;;
 
 (* ------------------------------------------------------------------------- *)
@@ -175,7 +173,7 @@ module Hol : Hol_kernel = struct
   type thm = Sequent of (term list * term * int)
 
 (*---------------------------------------------------------------------------*)
-(* Proof tracing implementation and storage.                                 *)
+(* Proof dumping.                                                            *)
 (*---------------------------------------------------------------------------*)
 
   type proof_content =
@@ -208,19 +206,21 @@ module Hol : Hol_kernel = struct
   | Psym of int
 
   type proof = Proof of (thm * proof_content)
-(*REMOVE
-  let the_proofs_idx = ref (-1)
+
+  let change_proof_content p c = let Proof(th,_) = p in Proof(th,c)
+
+  let thm_index = ref (-1)
 
   let oc_prf_dump = open_out "dump.prf"
 
   let new_theorem hyps concl proof_content =
-    let k = !the_proofs_idx + 1 in
-    the_proofs_idx := k;
+    let k = !thm_index + 1 in
+    thm_index := k;
     let thm = Sequent(hyps, concl, k) in
     output_value oc_prf_dump (Proof(thm,proof_content));
     thm
   ;;
-REMOVE*)
+
 (* ------------------------------------------------------------------------- *)
 (* List of current type constants with their arities.                        *)
 (*                                                                           *)
@@ -246,12 +246,12 @@ REMOVE*)
 (* ------------------------------------------------------------------------- *)
 (* Declare a new type.                                                       *)
 (* ------------------------------------------------------------------------- *)
-(*REMOVE
+
   let new_type(name,arity) =
     if can get_type_arity name then
       failwith ("new_type: type "^name^" has already been declared")
     else the_type_constants := (name,arity)::(!the_type_constants)
-REMOVE*)
+
 (* ------------------------------------------------------------------------- *)
 (* Basic type constructors.                                                  *)
 (* ------------------------------------------------------------------------- *)
@@ -339,12 +339,12 @@ REMOVE*)
 (* ------------------------------------------------------------------------- *)
 (* Declare a new constant.                                                   *)
 (* ------------------------------------------------------------------------- *)
-(*REMOVE
+
   let new_constant(name,ty) =
     if can get_const_type name then
       failwith ("new_constant: constant "^name^" has already been declared")
     else the_term_constants := (name,ty)::(!the_term_constants)
-REMOVE*)
+
 (* ------------------------------------------------------------------------- *)
 (* Finds the type of a term (assumes it is well-typed).                      *)
 (* ------------------------------------------------------------------------- *)
@@ -610,11 +610,11 @@ REMOVE*)
   let concl (Sequent(asl,c,_)) = c
 
   let index_of(Sequent(_,_,k)) = k
-(*REMOVE
+
 (* ------------------------------------------------------------------------- *)
 (* Basic equality properties; TRANS is derivable but included for efficiency *)
 (* ------------------------------------------------------------------------- *)
-
+(*REMOVE
   let REFL tm = new_theorem [] (safe_mk_eq tm tm) (Prefl tm)
 
   let TRANS (Sequent(asl1,c1,k1)) (Sequent(asl2,c2,k2)) =
@@ -800,7 +800,6 @@ REMOVE*)
     | Comb(Abs(v,bod),arg) ->
       new_theorem [] (safe_mk_eq tm (vsubst [arg,v] bod)) (Pbeta tm)
     | _ -> failwith "BETA_CONV: Not a beta-redex";;
-
 REMOVE*)
 (* ------------------------------------------------------------------------- *)
 (* Handling of axioms.                                                       *)
@@ -809,13 +808,13 @@ REMOVE*)
   let the_axioms = ref ([]:thm list)
 
   let axioms() = !the_axioms
-(*REMOVE
+
   let new_axiom tm =
     if Stdlib.compare (type_of tm) bool_ty = 0 then
       let th = new_theorem [] tm (Paxiom tm) in
       (the_axioms := th::(!the_axioms); th)
     else failwith "new_axiom: Not a proposition"
-REMOVE*)
+
 (* ------------------------------------------------------------------------- *)
 (* Handling of (term) definitions.                                           *)
 (* ------------------------------------------------------------------------- *)
@@ -823,7 +822,7 @@ REMOVE*)
   let the_definitions = ref ([]:thm list)
 
   let definitions() = !the_definitions
-(*REMOVE
+
   let new_basic_definition tm =
     match tm with
       Comb(Comb(Const("=",_),Var(cname,ty)),r) ->
@@ -837,7 +836,7 @@ REMOVE*)
              let dth = new_theorem [] dtm (Pdef(dtm,cname,ty)) in
              (the_definitions := dth::(!the_definitions); dth)
     | _ -> failwith "new_basic_definition"
-REMOVE*)
+
 (* ------------------------------------------------------------------------- *)
 (* Handling of type definitions.                                             *)
 (*                                                                           *)
@@ -850,7 +849,7 @@ REMOVE*)
 (*                                                                           *)
 (* Where "abs" and "rep" are new constants with the nominated names.         *)
 (* ------------------------------------------------------------------------- *)
-(*REMOVE
+
   let new_basic_type_definition tyname (absname,repname) (Sequent(asl,c,p)) =
     if exists (can get_const_type) [absname; repname] then
       failwith "new_basic_type_definition: Constant(s) already in use" else
@@ -879,14 +878,15 @@ REMOVE*)
     let _ = new_axiom atm in
     let _ = new_axiom rtm in
     (ath,rth)
-REMOVE*)
+
 (* ------------------------------------------------------------------------- *)
 (* Function to dump types, constants and axioms.                             *)
 (* ------------------------------------------------------------------------- *)
-(*REMOVE
+
   let dump_signature filename =
+    Printf.printf "generate %s ...\n%!" filename;
     let oc = open_out filename in
-    let nb_proofs = !the_proofs_idx + 1 in
+    let nb_proofs = !thm_index + 1 in
     output_value oc nb_proofs;
     output_value oc (types());
     output_value oc (constants());
@@ -895,7 +895,7 @@ REMOVE*)
     close_out oc;
     Printf.printf "%d proof steps\n%!" nb_proofs
   ;;
-REMOVE*)
+
 end;;
 
 include Hol;;

--- a/main.ml
+++ b/main.ml
@@ -443,72 +443,20 @@ dump_map_thid_name "%s.thm" %a;;
      read_pos basename;
      read_use basename;
      init_proof_reading basename;
-     (*let map = ref MapInt.empty in
-     let add i j = map := MapInt.add i j !map in
-     let find i = MapInt.find_opt i !map in
-     let update_cons v f i =
-       match find i with
-       | Some i -> f i
-       | None -> v
-     in
-     let update_cons2 v f i j =
-       match find i, find j with
-       | None, None -> v
-       | Some i, None -> f i j
-       | None, Some j -> f i j
-       | Some i, Some j -> f i j
-     in
-     let update_cons3 v f i j k =
-       match find i, find j, find k with
-       | None, None, None -> v
-       | None, None, Some k -> f i j k
-       | None, Some j, None -> f i j k
-       | None, Some j, Some k -> f i j k
-       | Some i, None, None -> f i j k
-       | Some i, None, Some k -> f i j k
-       | Some i, Some j, None -> f i j k
-       | Some i, Some j, Some k -> f i j k
-     in
-     let update_content c =
-       match c with
-       | Prefl _
-       | Pbeta _
-       | Passume _
-       | Paxiom _
-       | Pdef _
-       | Ptruth
-         -> c
-       | Ptrans(i,j) -> update_cons2 c (fun i j -> Ptrans(i,j)) i j
-       | Pmkcomb(i,j) -> update_cons2 c (fun i j -> Pmkcomb(i,j)) i j
-       | Pabs(i,t) -> update_cons c (fun i -> Pabs(i,t)) i
-       | Peqmp(i,j) -> update_cons2 c (fun i j -> Peqmp(i,j)) i j
-       | Pdeduct(i,j) -> update_cons2 c (fun i j -> Pdeduct(i,j)) i j
-       | Pinst(i,s) -> update_cons c (fun i -> Pinst(i,s)) i
-       | Pinstt(i,s) -> update_cons c (fun i -> Pinstt(i,s)) i
-       | Pdeft(i,t,s,b) -> update_cons c (fun i -> Pdeft(i,t,s,b)) i
-       | Pconj(i,j) -> update_cons2 c (fun i j -> Pconj(i,j)) i j
-       | Pconjunct1 i -> update_cons c (fun i -> Pconjunct1 i) i
-       | Pconjunct2 i -> update_cons c (fun i -> Pconjunct2 i) i
-       | Pmp(i,j) -> update_cons2 c (fun i j -> Pmp(i,j)) i j
-       | Pdisch(t,i) -> update_cons c (fun i -> Pdisch(t,i)) i
-       | Pspec(t,i) -> update_cons c (fun i -> Pspec(t,i)) i
-       | Pgen(t,i) -> update_cons c (fun i -> Pgen(t,i)) i
-       | Pexists(t,u,i) -> update_cons c (fun i -> Pexists(t,u,i)) i
-       | Pchoose(t,i,j) ->update_cons2 c (fun i j -> Pchoose(t,i,j)) i j
-       | Pdisj1(t,i) -> update_cons c (fun i -> Pdisj1(t,i)) i
-       | Pdisj2(t,i) -> update_cons c (fun i -> Pdisj2(t,i)) i
-       | Pdisj_cases(i,j,k) ->
-          update_cons3 c (fun i j k -> Pdisj_cases(i,j,k)) i j k
-       | Psym i -> update_cons c (fun i -> Psym i) i
-     in*)
      let dump_file = basename ^ "-simp.prf" in
      log "generate %s ...\n%!" dump_file;
      let oc = open_out_bin dump_file in
      let n = ref 0 in
+     let map = ref MapInt.empty in
+     let add i p = map := MapInt.add i p !map in
+     let proof_at j = try MapInt.find j !map with Not_found -> proof_at j in
      let pc_at j = let Proof(_,c) = proof_at j in c in
      let simp k p =
        let default() = output_value oc p in
-       let out pc = incr n; output_value oc (change_proof_content p pc) in
+       let out pc =
+         let p = change_proof_content p pc in
+         incr n; add k p; output_value oc p
+       in
        if Array.get !last_use k < 0 then out Ptruth else
        let Proof(_,c) = p in
        match c with
@@ -570,7 +518,7 @@ dump_map_thid_name "%s.thm" %a;;
      output_value oc last_use;
      let unused = ref 0 in
      Array.iter (fun k -> if k < 0 then incr unused) last_use;
-     log "%d unused theorems (%d%%)\n" !unused ((100 * !unused) / nb_proofs)
+     log "%d useless steps (%d%%)\n" !unused ((100 * !unused) / nb_proofs)
 
   | ["dg";nb_parts;b] ->
      let nb_parts = integer nb_parts in

--- a/main.ml
+++ b/main.ml
@@ -393,11 +393,17 @@ dump_map_thid_name "%s.thm" %a;;
      let nb_proofs = read_nb_proofs b in
      let thm_uses = Array.make nb_proofs 0 in
      let rule_uses = Array.make nb_rules 0 in
-     read_prf b
-       (fun _ p -> count_thm_uses thm_uses p; count_rule_uses rule_uses p);
+     let unused = ref 0 in
+     read_use b;
+     let f k p =
+       if Array.get !Xproof.last_use k >= 0 then
+         (count_thm_uses thm_uses p; count_rule_uses rule_uses p)
+       else incr unused
+     in
+     read_prf b f;
      log "compute statistics ...\n";
      print_histogram thm_uses;
-     print_rule_uses rule_uses nb_proofs;
+     print_rule_uses rule_uses (nb_proofs - !unused);
      0
 
   | ["simp";b] ->

--- a/main.ml
+++ b/main.ml
@@ -29,6 +29,18 @@ hol2dk dump-use $file.[ml|hl]
 hol2dk pos $file
   generate $file.pos, the positions of proofs in $file.prf
 
+hol2dk use $file
+  generate $file.use, some data to know whether a theorem is used or not
+
+hol2dk simp $file
+  simplify $file.prf and recompute $file.pos and $file.use
+
+hol2dk proof $file $x $y
+  print proof steps between theorem indexes $x and $y
+
+hol2dk print use $file $x
+  print the contents of $file.use for theorem index $x
+
 Single-threaded dk/lp file generation:
 --------------------------------------
 
@@ -56,9 +68,6 @@ hol2dk thm $file.[dk|lp]
 
 hol2dk axm $file.[dk|lp]
   generate $file_opam.[dk|lp] from $file.thm
-
-hol2dk use $file
-  generate $file.use, the number of times each proof step is used
 
 hol2dk part $n $k $x $y $file.[dk|lp]
   generate dk/lp proof files of part $k in [1..$n]

--- a/main.ml
+++ b/main.ml
@@ -335,7 +335,8 @@ dump_signature "%s.sig";;
 dump_map_thid_name "%s.thm" %a;;
 |} f f b b (olist ostring) (trans_file_deps (dep_graph (files())) f);
         close_out oc;
-        exit (Sys.command ("ocaml -w -A dump.ml && mv -f dump.prf "^b^".prf"))
+        exit (Sys.command
+                ("ocaml -w -A dump.ml && mv -f dump.prf "^b^"-origin.prf"))
      | _ -> wrong_arg()
      end
 
@@ -439,11 +440,12 @@ dump_map_thid_name "%s.thm" %a;;
      let n = !n and total = nb_proofs() in
      log "%d simplifications (%d%%)\n" n ((100 * n) / total)
 
-  | ["simp";basename] ->
+  | ["simp";b] ->
+     let basename = b ^ "-origin" in
      read_pos basename;
      read_use basename;
      init_proof_reading basename;
-     let dump_file = basename ^ "-simp.prf" in
+     let dump_file = b ^ ".prf" in
      log "generate %s ...\n%!" dump_file;
      let oc = open_out_bin dump_file in
      let n = ref 0 in

--- a/main.ml
+++ b/main.ml
@@ -233,7 +233,7 @@ let make b =
               %s_part_%d_term_abbrevs.%so %s_axioms.%so"
         b j e e b e b j e b e b j e b e;
       for j = 0 to i - 1 do
-        if dg.(i).(j) > 0 then out oc " %s_part_%d.%so" b (j+1) e
+        if dg.(i).(j) then out oc " %s_part_%d.%so" b (j+1) e
       done;
       out oc "\n"
     done;
@@ -504,24 +504,30 @@ dump_map_thid_name "%s.thm" %a;;
      let part idx =
        let k = idx / part_size in
        if k >= nb_parts - 1 then nb_parts - 1 else k in
-     let dg = Array.init nb_parts (fun i -> Array.make i 0) in
+     let dg = Array.init nb_parts (fun i -> Array.make i false) in
      let add_dep x =
        let px = part x in
        fun y ->
        let py = part y in
        if px <> py then
          begin
-           (*try*) dg.(px).(py) <- dg.(px).(py) + 1
+           (*try*) dg.(px).(py) <- true (*dg.(px).(py) + 1*)
            (*with (Invalid_argument _) as e ->
              log "x = %d, px = %d, y = %d, py = %d\n%!" x px y py;
              raise e*)
          end
      in
-     read_prf b (fun idx p -> List.iter (add_dep idx) (deps p));
+     read_use b;
+     let f k p =
+       if Array.get !Xproof.last_use k >= 0 then
+         List.iter (add_dep k) (deps p)
+     in
+     read_prf b f;
      for i = 1 to nb_parts - 1 do
        log "%d:" (i+1);
        for j = 0 to i - 1 do
-         if dg.(i).(j) > 0 then log " %d (%d)" (j+1) dg.(i).(j)
+         (*if dg.(i).(j) > 0 then log " %d (%d)" (j+1) dg.(i).(j)*)
+         if dg.(i).(j) then log " %d" (j+1)
        done;
        log "\n"
      done;

--- a/main.ml
+++ b/main.ml
@@ -394,52 +394,6 @@ dump_map_thid_name "%s.thm" %a;;
      print_histogram thm_uses;
      print_rule_uses rule_uses nb_proofs
 
-  | ["nb-simps";basename] ->
-     read_pos basename;
-     read_use basename;
-     init_proof_reading basename;
-     let n = ref 0 in
-     let simp k p =
-       if Array.get !last_use k >= 0 then
-       let Proof(_,c) = p in
-       match c with
-       | Ptrans(i,j) ->
-          begin match proof_at i with
-          | Proof(_,Prefl _) -> incr n
-          | _ ->
-             match proof_at j with
-             | Proof(_,Prefl _) -> incr n
-             | _ -> ()
-          end
-       | Psym i ->
-          let Proof(_,c) = proof_at i in
-          begin
-            match c with
-            | Prefl _
-            | Psym _
-            | Ptrans _ -> incr n
-            | _ -> ()
-          end
-       | Pconjunct1 i | Pconjunct2 i ->
-          begin match proof_at i with
-          | Proof(_,Pconj _) -> incr n
-          | _ -> ()
-          end
-       | Pmkcomb(i,j) ->
-          begin match proof_at i with
-          | Proof(_,Prefl _) ->
-             begin match proof_at j with
-             | Proof(_,Prefl _) -> incr n
-             | _ -> ()
-             end
-          | _ -> ()
-          end
-       | _ -> ()
-     in
-     iter_proofs_at simp;
-     let n = !n and total = nb_proofs() in
-     log "%d simplifications (%d%%)\n" n ((100 * n) / total)
-
   | ["simp";b] ->
      let basename = b ^ "-origin" in
      read_pos basename;

--- a/renaming.lp
+++ b/renaming.lp
@@ -3,7 +3,7 @@
 
 builtin "minus" ≔ -;
 builtin "minus_def" ≔ -_def;
-builtin "pair'" ≔ -';
+builtin "minus'" ≔ -';
 builtin "gt" ≔ >;
 builtin "gt_def" ≔ >_def;
 builtin "ge" ≔ >=;

--- a/xdk.ml
+++ b/xdk.ml
@@ -642,7 +642,9 @@ let proofs_in_range oc = function
      let p = proof_at x in
      List.iter (fun k -> theorem_as_axiom oc k (proof_at k)) (deps p);
      theorem oc x p
-  | All -> iter_proofs_at (theorem oc)
+  | All ->
+     iter_proofs_at
+       (fun k p -> if Array.get !last_use k >= 0 then theorem oc k p)
   | Upto y -> proofs_in_interval oc 0 y
   | Inter(x,y) -> proofs_in_interval oc x y
 ;;

--- a/xlib.ml
+++ b/xlib.ml
@@ -381,6 +381,38 @@ let canonical_term =
 (* Functions on proofs. *)
 (****************************************************************************)
 
+(* [proof oc p] prints the proof [p] on out_channel [oc]. *)
+let proof oc (Proof(_,c)) =
+  match c with
+  | Prefl _ -> out oc "refl"
+  | Ptrans(i,j) -> out oc "trans %d %d" i j
+  | Pmkcomb(i,j) -> out oc "mkcomb %d %d" i j
+  | Pabs(i,_) -> out oc "abs %d" i
+  | Pbeta _ -> out oc "beta"
+  | Passume _ -> out oc "assume"
+  | Peqmp(i,j) -> out oc "eqmp %d %d" i j
+  | Pdeduct(i,j) -> out oc "deduct %d %d" i j
+  | Pinst(i,_) -> out oc "inst %d" i
+  | Pinstt(i,_) -> out oc "inst_type %d" i
+  | Paxiom _ -> out oc "axiom"
+  | Pdef _ -> out oc "def"
+  | Pdeft(i,_,_,_) -> out oc "def_type %d" i
+  | Ptruth -> out oc "truth"
+  | Pconj(i,j) -> out oc "conj %d %d" i j
+  | Pconjunct1 i -> out oc "conjunct1 %d" i
+  | Pconjunct2 i -> out oc "conjunct2 %d" i
+  | Pmp(i,j) -> out oc "mp %d %d" i j
+  | Pdisch(_,i) -> out oc "disch %d" i
+  | Pspec(_,i) -> out oc "spec %d" i
+  | Pgen(_,i) -> out oc "gen %d" i
+  | Pexists(_,_,i) -> out oc "exists %d" i
+  | Pdisj1(_,i) -> out oc "disj1 %d" i
+  | Pdisj2(_,i) -> out oc "disj2 %d" i
+  | Pdisj_cases(i,j,k) -> out oc "disj_cases %d %d %d" i j k
+  | Pchoose(_,i,j) -> out oc "choose %d %d" i j
+  | Psym i -> out oc "sym %d" i
+;;
+
 (* [get_eq_typ p] returns the type [b] of the terms t and u of the
    conclusion of the proof [p] assumed of the form [= t u]. *)
 let get_eq_typ p =

--- a/xlib.ml
+++ b/xlib.ml
@@ -536,8 +536,9 @@ let print_rule_uses (a : int array) (nb_proofs : int) : unit =
   let total = float_of_int nb_proofs in
   let part n = float_of_int (100 * n) /. total in
   Array.iteri
-    (fun i n -> log "%10s %9d %2.0f%%\n" (name_of_code i) n (part n)) a;
-  log "truth counts the number of unused theorems + 1\n"
+    (fun i n -> log "%10s %9d %3.0f%%\n" (name_of_code i) n (part n)) a;
+  let total = Array.fold_left (+) 0 a in
+  log "%10s %9d %3.0f%%\n" "TOTAL" total (part total)
 ;;
 
 (****************************************************************************)

--- a/xlib.ml
+++ b/xlib.ml
@@ -381,7 +381,8 @@ let canonical_term =
 (* Functions on proofs. *)
 (****************************************************************************)
 
-(* [proof oc p] prints the proof [p] on out_channel [oc]. *)
+(* [proof oc p] prints the proof [p] on out_channel [oc] in a user
+   readable format. *)
 let proof oc (Proof(_,c)) =
   match c with
   | Prefl _ -> out oc "refl"

--- a/xlp.ml
+++ b/xlp.ml
@@ -534,7 +534,9 @@ let proofs_in_range oc = function
 "flag \"print_implicits\" on;
 flag \"print_domains\" on;
 print thm_%d;\n" x*)
-  | All -> iter_proofs_at (theorem oc)
+  | All ->
+     iter_proofs_at
+       (fun k p -> if Array.get !last_use k >= 0 then theorem oc k p)
   | Upto y -> proofs_in_interval oc 0 y
   | Inter(x,y) -> proofs_in_interval oc x y
 ;;

--- a/xproof.ml
+++ b/xproof.ml
@@ -43,8 +43,8 @@ let proof_at k =
   input_value ic
 ;;
 
-(* [!last_use.(i) = 0] if i is a named theorem, the highest theorem
-   index j using i if there is one, and -1 otherwise. *)
+(* [!last_use.(i) = 0] if [i] is a named theorem, the highest theorem
+   index using [i] if there is one, and -1 otherwise. *)
 let last_use : int array ref = ref [||];;
 
 let read_use basename = last_use := read_val (basename ^ ".use");;
@@ -52,16 +52,16 @@ let read_use basename = last_use := read_val (basename ^ ".use");;
 (* [!cur_part_max] indicates the maximal index of the current part. *)
 let cur_part_max : int ref = ref (-1);;
 
-(* [iter_proofs f] runs [f k (proof_at k)] on all proof index [k] from
-   0 to [nb_proofs() - 1]. Can be used after [read_pos], [read_use] and
-   [init_proof_reading] only. *)
+(* [iter_proofs_at f] runs [f k (proof_at k)] on all proof index [k]
+   from 0 to [nb_proofs() - 1] (including unused proofs). Can be used
+   after [read_pos] and [init_proof_reading] only. *)
 let iter_proofs_at (f : int -> proof -> unit) =
   let idx = ref 0 in
   let n = nb_proofs() in
   try
     while !idx < n do
       let k = !idx in
-      if Array.get !last_use k >= 0 then f k (proof_at k);
+      f k (proof_at k);
       idx := k + 1
     done
   with Failure _ as e ->


### PR DESCRIPTION
- add-links: do not create directory anymore + add link to Makefile
- xproof: iter_proofs_at does not check usefulness anymore; this must be done in the function argument f
- xlib: renamings + print_histogram prints the number of unused elements
- add command simp to generate a new simpler prf file

For hol.ml, this reduces the number of useful proof steps from 7792170 to 6093762 (-22%), lp files from 1.9 Go to 1.6 Go, coq files from 1.8 Go to 1.5 Go.

TODO:
- [x] remove command nb-simps
- [x] propagate simplifications
- [x] update README with new data
- [x] main.ml: remove dead code of update_content
- [x] fix hol2dk stat output
- [x] do not include useless steps in hol2dk dg