### PR TITLE
use maximal sharing for building abbreviation maps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Makefile to generate and check lp and coq files generated with split
 - command size to get statistics on the size of terms
 - option --sharing for using maximal sharing when recording term abbreviations
+- option --print-stats to print statistics on hash tables at exit
 
 ### Modified
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,12 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (an stp file contains the starting position of the corresponding proof)
 - command theorem to generate the lp files corresponding to a named theorem
 - Makefile to generate and check lp and coq files generated with split
-- fusion.ml: do not generate new theorems for empty instantiations
+- command size to get statistics on the size of terms
+- option --sharing for using maximal sharing when recording term abbreviations
 
 ### Modified
 
 - identifier renamings
 - merged the command dg in the command mk
+- fusion.ml: do not generate new theorems for empty instantiations
 
 ## 0.0.1 (2023-11-22)
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(BASE_FILES:%=%.lp) &:
 lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp)
 
 %.lp: %.sti
-	hol2dk theorem $(BASE) $@
+	hol2dk --sharing theorem $(BASE) $@
 
 .PHONY: clean-lp
 clean-lp:

--- a/NOTES.md
+++ b/NOTES.md
@@ -15,7 +15,7 @@ with split and -j32, hol.lp is generated in 42s instead of 32s (+31%)
 
 in singly-threaded mode, hol.lp is generated in 5m56s instead of 4m7s (+44%)
 
-however GRASSMANN_PLUCKER_4.lp can now be generated in 397 minutes
+however GRASSMANN_PLUCKER_4.lp can now be generated in 128 minutes
 
 ## 11/01/24
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -17,6 +17,12 @@ in singly-threaded mode, hol.lp is generated in 4m59s instead of 4m7s (+21%)
 
 however GRASSMANN_PLUCKER_4.lp can now be generated in 2 hours (119m23s)
 
+`Multivariate/make_upto_topology.ml`:
+  * lp 4h28m 48G type_abbrevs 47M term_abbrevs 42G with 38G by 3 files >1G:
+    - GRASSMANN_PLUCKER_4_term_abbrevs.lp 14G
+    - CHAIN_BOUNDARY_BOUNDARY_term_abbrevs.lp 5.2G
+    - HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS_term_abbrevs.lp 19G
+
 ## 11/01/24
 
 Translation of `hol.ml` with splitting: stp <1s lp 32s 1.1G v 43s 1.1G mkv 51s 2.7M vo (-j20) 28m 3.1G mklp 47s 2.7M lpo (-j32) 96m 0.9G
@@ -48,6 +54,7 @@ Translation of `100/isoperimetric.ml`:
 
 Translation of `Multivariate/make.ml`:
   * dump 35m52s 120 Go +16646 named theorems
+  * dump-simp 133 minutes (59% useless)
 
 Translation of `Multivariate/make_upto_derivatives.ml`:
   * dump 27m46s 91 Go + 14901 named theorems

--- a/NOTES.md
+++ b/NOTES.md
@@ -11,11 +11,11 @@ a solution is to use (maximal) sharing when building the map of term abbreviatio
 
 but sharing increases generation time significantly
 
-GRASSMANN_PLUCKER_4.lp can be generated in 116 minutes
+with split and -j32, hol.lp is generated in 42s instead of 32s (+31%)
 
-hol.lp is generated in 7m17s instead of 4m7s (+77%)
+in singly-threaded mode, hol.lp is generated in 5m56s instead of 4m7s (+44%)
 
-with split and -j32, hol.lp is generated in 48s instead of 32s (+50%)
+however GRASSMANN_PLUCKER_4.lp can now be generated in 397 minutes
 
 ## 11/01/24
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -11,11 +11,11 @@ a solution is to use (maximal) sharing when building the map of term abbreviatio
 
 but sharing increases generation time significantly
 
-with split and -j32, hol.lp is generated in 42s instead of 32s (+31%)
+with split and -j32, hol.lp is generated in 40s instead of 32s (+25%)
 
-in singly-threaded mode, hol.lp is generated in 5m56s instead of 4m7s (+44%)
+in singly-threaded mode, hol.lp is generated in 4m59s instead of 4m7s (+21%)
 
-however GRASSMANN_PLUCKER_4.lp can now be generated in 128 minutes
+however GRASSMANN_PLUCKER_4.lp can now be generated in 2 hours (119m23s)
 
 ## 11/01/24
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,22 @@
 NOTES
 -----
 
+## 17/01/24
+
+the generation of Multivariate/make_upto_topology/GRASSMANN_PLUCKER_4.lp takes too much memory
+
+the problem comes from the fact that the term abbreviations in this file are too big
+
+a solution is to use (maximal) sharing when building the map of term abbreviations
+
+but sharing increases generation time significantly
+
+GRASSMANN_PLUCKER_4.lp can be generated in 116 minutes
+
+hol.lp is generated in 7m17s instead of 4m7s (+77%)
+
+with split and -j32, hol.lp is generated in 48s instead of 32s (+50%)
+
 ## 11/01/24
 
 Translation of `hol.ml` with splitting: stp <1s lp 32s 1.1G v 43s 1.1G mkv 51s 2.7M vo (-j20) 28m 3.1G mklp 47s 2.7M lpo (-j32) 96m 0.9G

--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@ Results
 
 The HOL-Light base library `hol.ml` and the library `Logic/make.ml`
 formalizing the metatheory of first-order logic can be exported and
-translated to Dedukti, Lambdapi and Coq in a few minutes. However, it
-may take hours for Coq and require too much memory for Lambdapi to
-check the translated files. Bigger libraries like
-`Multivariate/make.ml` requires too much memory for the moment. We
-hope to fix this soon.
+translated to Dedukti, Lambdapi and Coq in a few minutes. The
+generated Dedukti files can be checked in a few minutes, but it takes
+a long time for Coq to check the generated files (28 minutes for
+`hol.ml`), and too much memory for Lambdapi.
+
+On the other hand, `hol2dk` may take several hours to translate the
+proofs of a few particular theorems like `GRASSMANN_PLUCKER_4`,
+`CHAIN_BOUNDARY_BOUNDARY` and
+`HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS` in `Multivariate/make`,
+because their proofs use a lot of big terms and sharing is not
+sufficient. We will work on improving this.
 
 Moreover, while it is possible to translate any HOL-Light proof to
 Coq, the translated theorem may not be directly usable by Coq users
@@ -36,7 +42,8 @@ the Coq standard library yet. Currently, only the type of natural
 numbers and various functions on natural numbers have been aligned. We
 gathered the obtained 448 lemmas in the package
 [coq-hol-light](https://github.com/Deducteam/coq-hol-light) available
-in the Coq Opam repository [released](https://github.com/coq/opam).
+in the Coq Opam repository [released](https://github.com/coq/opam). We
+are working on adding more mappings (lists, reals).
 
 Installing HOL-Light sources
 ----------------------------

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Dumping of `hol.ml`:
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `split`:
   * make sti: <1s
-  * make -j32 lp: 32s 1.1G, 48s with sharing
+  * make -j32 lp: 32s 1.1G, 40s with sharing
   * make mklp: 47s 2.7M
   * make -j32 lpo: 1h36m 0.9G
   * make -j32 v: 43s 1.1G

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Dumping of `hol.ml`:
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `split`:
   * make sti: <1s
-  * make -j32 lp: 32s 1.1G
+  * make -j32 lp: 32s 1.1G, 48s with sharing
   * make mklp: 47s 2.7M
   * make -j32 lpo: 1h36m 0.9G
   * make -j32 v: 43s 1.1G
@@ -447,7 +447,7 @@ Multi-threaded translation of `hol.ml` to Dedukti with `mk 100`:
   * kocheck: 5m54s
 
 Single-threaded translation of `hol.ml` to Lambdapi:
-  * lp files generation: 4m49s 1.1G type abbrevs 308K term abbrevs 525M (48%)
+  * lp files generation: 4m7s 1.1G type abbrevs 308K term abbrevs 524M (48%)
 
 Single-threaded translation of `hol.ml` to Dedukti:
   * dk files generation: 7m12s 1.4G type abbrevs 348K term abbrevs 590M (42%)

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 TODO
 ----
 
-- use hashconsing for building map_term
+- add abbreviations for closed terms
 
 - get rid of use file? in pos files, set pos to -1 for unused theorems?
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 TODO
 ----
 
+- extend split command to dedukti output
+
 - add abbreviations for closed terms
 
 - get rid of use file? in pos files, set pos to -1 for unused theorems?

--- a/fusion.ml
+++ b/fusion.ml
@@ -14,11 +14,17 @@ open Lib
 
 module type Hol_kernel =
   sig
-      type hol_type = private
+    type hol_type =
+      (*REMOVE
+      private
+      REMOVE*)
         Tyvar of string
       | Tyapp of string *  hol_type list
 
-      type term = private
+      type term =
+      (*REMOVE
+      private
+      REMOVE*)
         Var of string * hol_type
       | Const of string * hol_type
       | Comb of term * term

--- a/main.ml
+++ b/main.ml
@@ -336,8 +336,8 @@ let rec log_command l =
 and dump_and_simp after_hol f =
   let b = basename_ml f in
   match dump after_hol f b with
-  | 0 -> begin match command ["pos";b] with
-         | 0 -> begin match command ["use";b] with
+  | 0 -> begin match log_command ["pos";b] with
+         | 0 -> begin match log_command ["use";b] with
                 | 0 -> command ["simp";b]
                 | e -> e
                 end

--- a/main.ml
+++ b/main.ml
@@ -15,6 +15,8 @@ let usage() =
 hol2dk [-h|--help]
   print this help
 
+hol2dk [--sharing] command ...
+
 Dumping commands
 ----------------
 
@@ -351,6 +353,8 @@ and dump_and_simp after_hol f =
 
 and command = function
   | [] | ["-"|"--help"|"help"] -> usage(); 0
+
+  | "--sharing"::args -> sharing := true; command args
 
   | ["dep";f] ->
      let dg = dep_graph (files()) in

--- a/main.ml
+++ b/main.ml
@@ -15,7 +15,13 @@ let usage() =
 hol2dk [-h|--help]
   print this help
 
-hol2dk [--sharing] command ...
+hol2dk options command arguments
+
+Options
+-------
+
+--sharing: use sharing for recording term abbreviations
+--hstats: print statistics on hash tables at exit
 
 Dumping commands
 ----------------
@@ -134,8 +140,6 @@ hol2dk mk-coq $n $file
   generate a Makefile for translating to Coq each lp file generated
   by Makefile.lp and check them by using $n sequential calls to make
 %!"
-
-let percent k n = (100 * k) / n
 
 let wrong_arg() = Printf.eprintf "wrong argument(s)\n%!"; exit 1
 
@@ -356,6 +360,8 @@ and command = function
 
   | "--sharing"::args -> sharing := true; command args
 
+  | "--hstats"::args -> at_exit print_hstats; command args
+
   | ["dep";f] ->
      let dg = dep_graph (files()) in
      log "%a\n" (list_sep " " string) (trans_file_deps dg f);
@@ -475,7 +481,7 @@ and command = function
          end
      in
      read_prf b handle_proof;
-     log "%#d terms, term size average = %d, max = %#d, \
+     log "%#d terms, average size = %#d, max size = %#d, \
           %#d terms of size >%#d (%d%%)\n"
        !nb_terms (!sum_size / !nb_terms) !max_size
        !nb_terms_gtl l (percent !nb_terms_gtl !nb_terms);

--- a/main.ml
+++ b/main.ml
@@ -360,7 +360,7 @@ and command = function
 
   | "--sharing"::args -> sharing := true; command args
 
-  | "--hstats"::args -> at_exit print_hstats; command args
+  | "--print-stats"::args -> at_exit print_hstats; command args
 
   | ["dep";f] ->
      let dg = dep_graph (files()) in

--- a/main.ml
+++ b/main.ml
@@ -45,12 +45,6 @@ hol2dk rewrite $file
 hol2dk purge $file
   compute theorems that can be discarded in $file.use
 
-hol2dk proof $file $x $y
-  print proof steps between theorem indexes $x and $y
-
-hol2dk print use $file $x
-  print the contents of $file.use for theorem index $x
-
 Single-threaded dk/lp file generation
 -------------------------------------
 
@@ -59,6 +53,16 @@ hol2dk $file.[dk|lp]
 
 hol2dk $file.[dk|lp] $thm_id
   generate $file.[dk|lp] but with theorem index $thm_id only (for debug)
+
+Multi-threaded lp file generation by having a file for each named theorem
+-------------------------------------------------------------------------
+
+hol2dk split $file
+  generate $file.thp and the files $t.sti, $t.pos and $t.use
+  for each named theorem $t
+
+hol2dk theorem $file $t.lp
+  generate the lp proof of the theorem named $t
 
 Multi-threaded dk/lp file generation by splitting proofs in $n parts
 --------------------------------------------------------------------
@@ -79,36 +83,21 @@ hol2dk thm $file.[dk|lp]
 hol2dk axm $file.[dk|lp]
   generate $file_opam.[dk|lp] from $file.thm (same as thm but without proofs)
 
-Multi-threaded lp file generation by having a file for each named theorem
--------------------------------------------------------------------------
-
-hol2dk split $file
-  generate $file.thp and the files $t.sti, $t.pos and $t.use
-  for each named theorem $t
-
-hol2dk theorem $file $t.lp
-  generate the lp proof of the theorem named $t
-
-Experimental (not efficient)
-----------------------------
-
-hol2dk prf $x $y $file
-  generate a lp file for each proof from index $x to index $y in $file.prf
-  without using type and term abbreviations
-
-hol2dk mk-lp $jobs $file
-  generate Makefile.lp for generating with the option -j $jobs a lp file
-  (without type and term abbreviations) for each proof of $file.prf
-
-hol2dk mk-coq $n $file
-  generate a Makefile for translating to Coq each lp file generated
-  by Makefile.lp and check them by using $n sequential calls to make
-
 Other commands
 --------------
 
+hol2dk proof $file $x $y
+  print proof steps between theorem indexes $x and $y
+
+hol2dk print use $file $x
+  print the contents of $file.use for theorem index $x
+
 hol2dk stat $file
-  print statistics on $file.prf
+  print statistics on proofs
+
+hol2dk size $file [$lower_bound]
+  print statistics on the size of terms
+  and the number of terms of size greater than $lower_bound
 
 hol2dk dep
   print on stdout a Makefile giving the dependencies of all HOL-Light files
@@ -127,6 +116,21 @@ hol2dk name upto file.[ml|hl]
 hol2dk name
   print on stdout the named theorems proved in all HOL-Light files
   in the working directory and all its subdirectories recursively
+
+Experimental (not efficient)
+----------------------------
+
+hol2dk prf $x $y $file
+  generate a lp file for each proof from index $x to index $y in $file.prf
+  without using type and term abbreviations
+
+hol2dk mk-lp $jobs $file
+  generate Makefile.lp for generating with the option -j $jobs a lp file
+  (without type and term abbreviations) for each proof of $file.prf
+
+hol2dk mk-coq $n $file
+  generate a Makefile for translating to Coq each lp file generated
+  by Makefile.lp and check them by using $n sequential calls to make
 %!"
 
 let percent k n = (100 * k) / n
@@ -409,12 +413,12 @@ and command = function
      let rule_uses = Array.make nb_rules 0 in
      let unused = ref 0 in
      read_use b;
-     let f k p =
+     let handle_proof k p =
        if Array.get !Xproof.last_use k >= 0 then
          (count_thm_uses thm_uses p; count_rule_uses rule_uses p)
        else incr unused
      in
-     read_prf b f;
+     read_prf b handle_proof;
      log "compute statistics ...\n";
      print_histogram thm_uses;
      print_rule_uses rule_uses (nb_proofs - !unused);
@@ -442,6 +446,35 @@ and command = function
      log "compute statistics ...\n";
      print_histogram thm_uses;
      print_rule_uses rule_uses (nb_proofs - !unused);
+     0
+
+  | ["size";b] -> command ["size";b;"0"]
+  | ["size";b;l] ->
+     let l = integer l in
+     read_use b;
+     init_proof_reading b;
+     let max_size = ref 0 and sum_size = ref 0 and nb_terms = ref 0
+     and nb_terms_gtl = ref 0 in
+     let handle_term t =
+       incr nb_terms;
+       let s = size t in
+       if s > !max_size then max_size := s;
+       if s > l then incr nb_terms_gtl;
+       sum_size := s + !sum_size
+     in
+     let handle_proof k p =
+       if Array.get !Xproof.last_use k >= 0 then
+         begin
+           let Proof(th,_) = p in
+           let hs,c = dest_thm th in
+           handle_term c; List.iter handle_term hs
+         end
+     in
+     read_prf b handle_proof;
+     log "%#d terms, term size average = %d, max = %#d, \
+          %#d terms of size >%#d (%d%%)\n"
+       !nb_terms (!sum_size / !nb_terms) !max_size
+       !nb_terms_gtl l (percent !nb_terms_gtl !nb_terms);
      0
 
   | ["proof";b;x;y] ->
@@ -647,11 +680,11 @@ and command = function
          end
      in
      read_use b;
-     let f k p =
+     let handle_proof k p =
        if Array.get !Xproof.last_use k >= 0 then
          List.iter (add_dep k) (deps p)
      in
-     read_prf b f;
+     read_prf b handle_proof;
      for i = 1 to nb_parts - 1 do
        log "%d:" (i+1);
        for j = 0 to i - 1 do

--- a/xlib.ml
+++ b/xlib.ml
@@ -389,26 +389,73 @@ let el b =
 let mk_el b = mk_const("el",[b,aty]);;
 
 (****************************************************************************)
-(* Sharing of strings, types and terms. *)
+(* Canonical term for alpha-equivalence without sharing. *)
 (****************************************************************************)
 
-(*let hmap_string = ref MapStr.empty;;
+(* [canonical_term t] returns the free type and term variables of [t]
+   together with a term alpha-equivalent to [t] so that
+   [canonical_term t = canonical_term u] if [t] and [u] are
+   alpha-equivalent. *)
+let canonical_term =
+  (*let a_max = ref 0 and x_max = ref 0 and y_max = ref 0 in*)
+  let va = Array.init 20 (fun i -> mk_vartype ("a" ^ string_of_int i))
+  and sx = Array.init 50 (fun i -> "x" ^ string_of_int i)
+  and sy = Array.init 50 (fun i -> "y" ^ string_of_int i) in
+  let get_type = function Var(_,b) -> b | _ -> assert false in
+  let type_var i tv =
+    (*if i > !a_max then begin a_max := i; log "a_max = %d\n%!" i end;*)
+    let v =
+      if i < Array.length va then va.(i)
+      else (log "a_max = %d\n%!" i; mk_vartype ("a" ^ string_of_int i))
+    in v, tv
+  in
+  let term_var i v =
+    (*if i > !x_max then begin x_max := i; log "x_max = %d\n%!" i end;*)
+    match v with
+    | Var(_,b) ->
+       let s =
+         if i < Array.length sx then sx.(i)
+         else (log "x_max = %d\n%!" i; "x" ^ string_of_int i)
+       in v, mk_var(s,b)
+    | _ -> assert false
+  in
+  (* [subst i su t] applies [su] on [t] and rename abstracted
+     variables as well by incrementing the integer [i]. *)
+  let rec subst i su t =
+    (*log "subst %d %a %a\n%!" i (olist (opair oterm oterm)) su oterm t;*)
+    match t with
+    | Var _ -> (try List.assoc t su with Not_found -> assert false)
+    | Const _ -> t
+    | Comb(u,v) -> mk_comb(subst i su u, subst i su v)
+    | Abs(u,v) ->
+       match u with
+       | Var(_,b) ->
+          (*if i > !y_max then begin y_max := i; log "y_max = %d\n%!" i end;*)
+          let s =
+            if i < Array.length sy then sy.(i)
+            else (log "y_max = %d\n%!" i; "y" ^ string_of_int i)
+          in
+          let u' = mk_var(s,b) in
+          mk_abs(u', subst (i+1) ((u,u')::su) v)
+       | _ -> assert false
+  in
+  fun t ->
+  let tvs = type_vars_in_term t and vs = frees t in
+  let su = List.mapi type_var tvs in
+  let t' = inst su t and vs' = List.map (inst su) vs in
+  let bs = List.map get_type vs' and su' = List.mapi term_var vs' in
+  tvs, vs, bs, subst 0 su' t'
+;;
 
-let share_string x =
-  try MapStr.find x !hmap_string
-  with Not_found -> hmap_string := MapStr.add x x !hmap_string; x;;*)
+(****************************************************************************)
+(* Sharing of strings, types and terms. *)
+(****************************************************************************)
 
 let hmap_string : (string,string) Hashtbl.t = Hashtbl.create 100000;;
 
 let share_string x =
   try Hashtbl.find hmap_string x
   with Not_found -> Hashtbl.add hmap_string x x; x;;
-
-(*let hmap_type = ref MapTyp.empty;;
-
-let share_type x =
-  try MapTyp.find x !hmap_type
-  with Not_found -> hmap_type := MapTyp.add x x !hmap_type; x;;*)
 
 let hmap_type : (hol_type,hol_type) Hashtbl.t = Hashtbl.create 100000;;
 
@@ -422,12 +469,6 @@ let hmk_tyapp(s,bs) = share_type (Tyapp(share_string s,bs));;
 let rec htype = function
   | Tyvar s -> hmk_tyvar s
   | Tyapp(s,bs) -> hmk_tyapp(s, List.map htype bs);;
-
-(*let hmap_term = ref MapTrm.empty;;
-
-let share_term x =
-  try MapTrm.find x !hmap_term
-  with Not_found -> hmap_term := MapTrm.add x x !hmap_term; x;;*)
 
 let hmap_term : (term,term) Hashtbl.t = Hashtbl.create 1000000;;
 
@@ -446,11 +487,15 @@ let rec hterm = function
   | Comb(t,u) -> hmk_comb(hterm t, hterm u)
   | Abs(t,u) -> hmk_abs(hterm t, hterm u);;
 
+(****************************************************************************)
+(* Canonical term for alpha-equivalence with sharing. *)
+(****************************************************************************)
+
 (* [canonical_term t] returns the free type and term variables of [t]
    together with a term alpha-equivalent to [t] so that
    [canonical_term t = canonical_term u] if [t] and [u] are
    alpha-equivalent. *)
-let canonical_term =
+let hcanonical_term =
   (*let a_max = ref 0 and x_max = ref 0 and y_max = ref 0 in*)
   let va = Array.init 20 (fun i -> hmk_tyvar ("a" ^ string_of_int i))
   and sx = Array.init 50 (fun i -> "x" ^ string_of_int i)
@@ -500,6 +545,11 @@ let canonical_term =
   let bs = List.map get_type vs' and su' = List.mapi term_var vs' in
   tvs, vs, bs, subst 0 su' t'
 ;;
+
+let sharing = ref false;;
+
+let canonical_term t =
+  if !sharing then hcanonical_term t else canonical_term t;;
 
 (****************************************************************************)
 (* Functions on proofs. *)

--- a/xlib.ml
+++ b/xlib.ml
@@ -253,6 +253,12 @@ let arity =
 (* Functions on terms. *)
 (****************************************************************************)
 
+let rec size = function
+  | Var _ | Const _ -> 1
+  | Comb(u,v) -> 1 + size u + size v
+  | Abs(_,v) -> 2 + size v
+;;
+
 (* Printing function for debug. *)
 let rec oterm oc t =
   match t with
@@ -454,15 +460,17 @@ let canonical_term =
     (*if i > !a_max then begin a_max := i; log "a_max = %d\n%!" i end;*)
     let v =
       if i < Array.length va then va.(i)
-      else hmk_tyvar ("a" ^ string_of_int i)
+      else (log "a_max = %d\n%!" i; hmk_tyvar ("a" ^ string_of_int i))
     in v, tv
   in
   let term_var i v =
     (*if i > !x_max then begin x_max := i; log "x_max = %d\n%!" i end;*)
     match v with
     | Var(_,b) ->
-       let s = if i < Array.length sx then sx.(i) else "x" ^ string_of_int i in
-       v, hmk_var(s,b)
+       let s =
+         if i < Array.length sx then sx.(i)
+         else (log "x_max = %d\n%!" i; "x" ^ string_of_int i)
+       in v, hmk_var(s,b)
     | _ -> assert false
   in
   (* [subst i su t] applies [su] on [t] and rename abstracted
@@ -478,7 +486,9 @@ let canonical_term =
        | Var(_,b) ->
           (*if i > !y_max then begin y_max := i; log "y_max = %d\n%!" i end;*)
           let s =
-            if i < Array.length sy then sy.(i) else "y" ^ string_of_int i in
+            if i < Array.length sy then sy.(i)
+            else (log "y_max = %d\n%!" i; "y" ^ string_of_int i)
+          in
           let u' = hmk_var(s,b) in
           hmk_abs(u', subst (i+1) ((u,u')::su) v)
        | _ -> assert false

--- a/xlp.ml
+++ b/xlp.ml
@@ -81,13 +81,13 @@ let abbrev_typ =
         abbreviation if needed *)
      let tvs, b = canonical_typ b in
      let k =
-       match MapTyp.find_opt b !map_typ with
+       match TypHashtbl.find_opt htbl_type_abbrev b with
        | Some (k,_) -> k
        | None ->
           let k = !idx + 1 in
           idx := k;
           let x = (k, List.length tvs) in
-          map_typ := MapTyp.add b x !map_typ;
+          TypHashtbl.add htbl_type_abbrev b x;
           k
      in
      match tvs with
@@ -97,17 +97,18 @@ let abbrev_typ =
 
 let typ oc b = if !use_abbrev then abbrev_typ oc b else raw_typ oc b;;
 
-(* [decl_map_typ oc m] outputs on [oc] the type abbreviations of [m]. *)
-let decl_map_typ oc m =
-  let abbrev (b,(k,n)) =
+(* [decl_map_typ oc] outputs on [oc] the type abbreviations. *)
+let decl_map_typ oc =
+  let abbrev b (k,n) =
     out oc "symbol type%d" k;
     for i=0 to n-1 do out oc " a%d" i done;
     (* We can use [raw_typ] here since [b] canonical. *)
     out oc " ≔ %a;\n" raw_typ b
   in
-  List.iter abbrev
+  (*List.iter abbrev
     (List.sort (fun (_,(k1,_)) (_,(k2,_)) -> k1 - k2)
-       (MapTyp.fold (fun b x l -> (b,x)::l) m []))
+       (MapTyp.fold (fun b x l -> (b,x)::l) m []))*)
+  TypHashtbl.iter abbrev htbl_type_abbrev
 ;;
 
 (****************************************************************************)
@@ -216,7 +217,7 @@ let abbrev_term =
        abbreviation if needed *)
     let tvs, vs, bs, t = canonical_term t in
     let k =
-      match MapTrm.find_opt t !map_term with
+      match TrmHashtbl.find_opt htbl_term_abbrev t with
       | Some (k,_,_) -> k
       | None ->
          let k = !idx + 1 in
@@ -224,7 +225,7 @@ let abbrev_term =
          (*out oc_abbrevs "%a\n\n" raw_term t;*)
          idx := k;
          let x = (k, List.length tvs, bs) in
-         map_term := MapTrm.add t x !map_term;
+         TrmHashtbl.add htbl_term_abbrev t x;
          k
     in
     match tvs, vs with
@@ -259,20 +260,20 @@ let term rmap oc t =
   else unabbrev_term rmap oc (rename rmap t)
 ;;
 
-(* [decl_map_term oc m] outputs on [oc] the term abbreviations defined
-   by [m]. *)
-let decl_map_term oc m =
-  let abbrev (t,(k,n,bs)) =
+(* [decl_map_term oc] outputs on [oc] the term abbreviations. *)
+let decl_map_term oc =
+  let abbrev t (k,n,bs) =
     out oc "symbol term%d" k;
     for i=0 to n-1 do out oc " a%d" i done;
-    (* We can use abbrev_typ here since [bs] are canonical. *)
+    (* We can use [abbrev_typ] here since [bs] are canonical. *)
     List.iteri (fun i b -> out oc " (x%d: El %a)" i abbrev_typ b) bs;
     (* We can use [raw_term] here since [t] is canonical. *)
     out oc " ≔ %a;\n" raw_term t
   in
-  List.iter abbrev
+  (*List.iter abbrev
     (List.sort (fun (_,(k1,_,_)) (_,(k2,_,_)) -> k1 - k2)
-       (MapTrm.fold (fun b x l -> (b,x)::l) m []))
+       (MapTrm.fold (fun b x l -> (b,x)::l) m []))*)
+  TrmHashtbl.iter abbrev htbl_term_abbrev
 ;;
 
 (****************************************************************************)
@@ -583,7 +584,7 @@ let export_types b =
 
 let export_type_abbrevs b n s =
   export n (s ^ "_type_abbrevs")
-    (fun oc -> require oc b "_types"; decl_map_typ oc !map_typ)
+    (fun oc -> require oc b "_types"; decl_map_typ oc)
 ;;
 
 let constants() =
@@ -601,7 +602,7 @@ let export_term_abbrevs b n s =
     (fun oc ->
       List.iter (require oc b) ["_types"; "_terms"];
       List.iter (require oc n) [s ^ "_type_abbrevs"];
-      decl_map_term oc !map_term)
+      decl_map_term oc)
 ;;
 
 let export_axioms b =

--- a/xproof.ml
+++ b/xproof.ml
@@ -21,7 +21,6 @@ let ic_prf : in_channel ref = ref stdin;;
 
 let init_proof_reading b =
   let dump_file = b ^ ".prf" in
-  log "open %s ...\n%!" dump_file;
   ic_prf := open_in_bin dump_file;;
 
 (* [!the_start_idx] is the starting proof index of the current pos file. *)


### PR DESCRIPTION
- add command size to get statistics on the size of terms
- add option --sharing for using maximal sharing when recording term abbreviations
- add option --print-stats for printing statistics about hash tables used for sharing

sharing slows down lp file generation by 25% but allows to generate files that were out of reach before like Multivariate/make_upto_topology/GRASSMANN_PLUCKER_4.lp which takes about 2 hours to be generated with a single processor because terms are much bigger in this file