### PR TITLE
add sharing in the definitions of abbreviations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,14 +20,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - command theorem to generate the lp files corresponding to a named theorem
 - Makefile to generate and check lp and coq files generated with split
 - command size to get statistics on the size of terms
-- option --sharing for using maximal sharing when recording term abbreviations
 - option --print-stats to print statistics on hash tables at exit
+- use hash tables instead of maps to build abbreviations maps
+- use sharing when building canonical types and terms
+- use sharing in lp output for defining term abbreviations
 
 ### Modified
 
 - identifier renamings
 - merged the command dg in the command mk
 - fusion.ml: do not generate new theorems for empty instantiations
+
+### Fixed
+
+- valid dedukti and lambdapi identifiers
 
 ## 0.0.1 (2023-11-22)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - option --print-stats to print statistics on hash tables at exit
 - use hash tables instead of maps to build abbreviations maps
 - use sharing when building canonical types and terms
-- use sharing in lp output for defining term abbreviations
+- add option --use-sharing for using sharing in lp output when defining term abbreviations
 
 ### Modified
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ clean-lp:
 .PHONY: mklp
 mklp lp.mk:
 	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lp.sh {} \; > lp.mk
-	touch Makefile
+#	touch Makefile
 
 include lp.mk
 
@@ -68,7 +68,7 @@ clean-v:
 .PHONY: mkv
 mkv coq.mk: lp.mk
 	sed -e 's/\.lpo/.vo/g' -e 's/: theory_hol.vo/: coq.vo theory_hol.vo/' -e 's/theory_hol.vo:/theory_hol.vo: coq.vo/' lp.mk > coq.mk
-	touch Makefile
+#	touch Makefile
 #find . -maxdepth 1 -name '*.v' -exec $(HOL2DK_DIR)/dep-coq.sh {} \; > coq.mk
 
 include coq.mk

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean-lpo:
 	find . -maxdepth 1 -name '*.lpo' -delete
 
 .PHONY: v
-v: theory_hol.v $(BASE_FILES:%=%.v) $(STI_FILES:%.sti=%.v) $(STI_FILES:%.sti=%_type_abbrevs.v) $(STI_FILES:%.sti=%_term_abbrevs.v)
+v: theory_hol.v $(BASE_FILES:%=%.v) $(STI_FILES:%.sti=%.v) $(STI_FILES:%.sti=%_type_abbrevs.v) $(STI_FILES:%.sti=%_term_abbrevs.v) $(STI_FILES:%.sti=%_subterm_abbrevs.v)
 
 %.v: %.lp
 	@echo lambdapi export -o stt_coq $<

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ $(BASE_FILES:%=%.lp) &:
 .PHONY: lp
 lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp)
 
-CHAIN_BOUNDARY_BOUNDARY.lp GRASSMANN_PLUCKER_4.lp HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS.lp: HOL2DK_OPTIONS = --use-sharing
+FILES_WITH_SHARING = #CHAIN_BOUNDARY_BOUNDARY GRASSMANN_PLUCKER_4 HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS
+
+$(FILES_WITH_SHARING:%=%.lp): HOL2DK_OPTIONS = --use-sharing
 
 %.lp: %.sti
 	hol2dk $(HOL2DK_OPTIONS) theorem $(BASE) $@
@@ -40,7 +42,6 @@ clean-lp:
 .PHONY: mklp
 mklp lp.mk:
 	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lp.sh {} \; > lp.mk
-#	touch Makefile
 
 include lp.mk
 
@@ -55,7 +56,7 @@ clean-lpo:
 	find . -maxdepth 1 -name '*.lpo' -delete
 
 .PHONY: v
-v: theory_hol.v $(BASE_FILES:%=%.v) $(STI_FILES:%.sti=%.v) $(STI_FILES:%.sti=%_type_abbrevs.v) $(STI_FILES:%.sti=%_term_abbrevs.v) $(STI_FILES:%.sti=%_subterm_abbrevs.v)
+v: theory_hol.v $(BASE_FILES:%=%.v) $(STI_FILES:%.sti=%.v) $(STI_FILES:%.sti=%_type_abbrevs.v) $(STI_FILES:%.sti=%_term_abbrevs.v) $(FILES_WITH_SHARING:%=%_subterm_abbrevs.v)
 
 %.v: %.lp
 	@echo lambdapi export -o stt_coq $<
@@ -68,13 +69,12 @@ clean-v:
 .PHONY: mkv
 mkv coq.mk: lp.mk
 	sed -e 's/\.lpo/.vo/g' -e 's/: theory_hol.vo/: coq.vo theory_hol.vo/' -e 's/theory_hol.vo:/theory_hol.vo: coq.vo/' lp.mk > coq.mk
-#	touch Makefile
 #find . -maxdepth 1 -name '*.v' -exec $(HOL2DK_DIR)/dep-coq.sh {} \; > coq.mk
 
 include coq.mk
 
 .PHONY: vo
-vo: coq.vo theory_hol.vo $(BASE_FILES:%=%.vo) $(STI_FILES:%.sti=%.vo) $(STI_FILES:%.sti=%_type_abbrevs.vo) $(STI_FILES:%.sti=%_term_abbrevs.vo)
+vo: coq.vo theory_hol.vo $(BASE_FILES:%=%.vo) $(STI_FILES:%.sti=%.vo) $(STI_FILES:%.sti=%_type_abbrevs.vo) $(STI_FILES:%.sti=%_term_abbrevs.vo) $(FILES_WITH_SHARING:%=%_subterm_abbrevs.vo)
 
 %.vo: %.v
 	coqc -R . HOLLight $<

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ clean-lpo:
 v: theory_hol.v $(BASE_FILES:%=%.v) $(STI_FILES:%.sti=%.v) $(STI_FILES:%.sti=%_type_abbrevs.v) $(STI_FILES:%.sti=%_term_abbrevs.v)
 
 %.v: %.lp
-	lambdapi export -o stt_coq --encoding $(HOL2DK_DIR)/encoding.lp --renaming $(HOL2DK_DIR)/renaming.lp --erasing $(HOL2DK_DIR)/erasing.lp --use-notations --requiring coq.v $< | sed -e 's/^Require Import hol-light\./Require Import /g' > $@
+	@echo lambdapi export -o stt_coq $<
+	@lambdapi export -o stt_coq --encoding $(HOL2DK_DIR)/encoding.lp --renaming $(HOL2DK_DIR)/renaming.lp --erasing $(HOL2DK_DIR)/erasing.lp --use-notations --requiring coq.v $< | sed -e 's/^Require Import hol-light\./Require Import /g' > $@
 
 .PHONY: clean-v
 clean-v:

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,11 @@
 NOTES
 -----
 
+## 25/01/24
+
+By introducing sharing in term abbreviations, we can reduce the the size of some lp files significantly:
+- CHAIN_BOUNDARY_BOUNDARY.lp is generated in 59m37s and the size of the term_abbrevs.lp file is reduced from 5.2G to 1.9G (-63%)
+
 ## 19/01/24
 
 Arithmetic/make:

--- a/NOTES.md
+++ b/NOTES.md
@@ -3,8 +3,106 @@ NOTES
 
 ## 25/01/24
 
-By introducing sharing in term abbreviations, we can reduce the the size of some lp files significantly:
-- CHAIN_BOUNDARY_BOUNDARY.lp is generated in 59m37s and the size of the term_abbrevs.lp file is reduced from 5.2G to 1.9G (-63%)
+By introducing sharing in term abbreviations, we can reduce the size of some lp files significantly:
+
+| term_abbrevs.lp file                    | generation | size w/o sharing | size w/ sharing | %    |
+|-----------------------------------------|------------|------------------|-----------------|------|
+| CHAIN_BOUNDARY_BOUNDARY                 | 56m29s     | 5.2G             | 1.9G            | -63% |
+| GRASSMANN_PLUCKER_4                     | 3h25m27s   | 14G              | 4.7G            | -66% |
+| HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS | 6h48m57s   | 19G              | 5.3G            | -72% |
+
+but coq checking is slowed down: the checking of `hol.ml` takes 40m29s 3.5G with sharing and -j16 (it fails now with -j20) instead of 32m20s 3.1G with -j20 before.
+
+statistics on hashtables for CHAIN_BOUNDARY_BOUNDARY:
+  we need to improve the hash function on big terms
+
+string: 362_900 bindings, 262_144 buckets, 1.38 bindings/bucket, max 10
+buckets with 0 bindings: 65_814 (25% of buckets)
+
+| bindings | buckets | %   | cumulated | % bindings |
+|----------|---------|-----|-----------|------------|
+| 1        | 90_480  | 24% | 90_480    | 24%        |
+| 2        | 63_195  | 34% | 216_870   | 59%        |
+| 3        | 29_063  | 24% | 304_059   | 83%        |
+| 4        | 10_028  | 11% | 344_171   | 94%        |
+| 5        | 2_823   | 3%  | 358_286   | 98%        |
+| 6        | 598     | 0%  | 361_874   | 99%        |
+| 7        | 124     | 0%  | 362_742   | 99%        |
+| 8        | 14      | 0%  | 362_854   | 99%        |
+| 9        | 4       | 0%  | 362_890   | 99%        |
+| 10       | 1       | 0%  | 362_900   | 100%       |
+
+type: 371 bindings, 131_072 buckets, 0.00 bindings/bucket, max 9
+buckets with 0 bindings: 130_759 (99% of buckets)
+
+| bindings | buckets | %   | cumulated | % bindings |
+|----------|---------|-----|-----------|------------|
+| 1        | 278     | 74% | 278       | 74%        |
+| 2        | 24      | 12% | 326       | 87%        |
+| 3        | 5       | 4%  | 341       | 91%        |
+| 4        | 4       | 4%  | 357       | 96%        |
+| 5        | 1       | 1%  | 362       | 97%        |
+| 6        | 0       | 0%  | 362       | 97%        |
+| 7        | 0       | 0%  | 362       | 97%        |
+| 8        | 0       | 0%  | 362       | 97%        |
+| 9        | 1       | 2%  | 371       | 100%       |
+
+term: 382_063 bindings, 1_048_576 buckets, 0.36 bindings/bucket, max 46_266
+buckets with 0 bindings: 1_024_846 (97% of buckets)
+
+| bindings | buckets | %  | cumulated | % bindings |
+|----------|---------|----|-----------|------------|
+| 1        | 17_769  | 4% | 17_769    | 4%         |
+| 2        | 2_855   | 1% | 23_479    | 6%         |
+| 3        | 976     | 0% | 26_407    | 6%         |
+| 4        | 602     | 0% | 28_815    | 7%         |
+| 5        | 287     | 0% | 30_250    | 7%         |
+| 6        | 253     | 0% | 31_768    | 8%         |
+| 7        | 134     | 0% | 32_706    | 8%         |
+| 8        | 111     | 0% | 33_594    | 8%         |
+| 9        | 85      | 0% | 34_359    | 8%         |
+| 10       | 69      | 0% | 35_049    | 9%         |
+
+type_abbrev: 121 bindings, 131_072 buckets, 0.00 bindings/bucket, max 3
+buckets with 0 bindings: 130_957 (99% of buckets)
+
+| bindings | buckets | %   | cumulated | % bindings |
+|----------|---------|-----|-----------|------------|
+| 1        | 110     | 90% | 110       | 90%        |
+| 2        | 4       | 6%  | 118       | 97%        |
+| 3        | 1       | 2%  | 121       | 100%       |
+
+term_abbrev: 265_885 bindings, 1_048_576 buckets, 0.25 bindings/bucket, max 41_447
+buckets with 0 bindings: 1_043_364 (99% of buckets)
+
+| bindings | buckets | %  | cumulated | % bindings |
+|----------|---------|----|-----------|------------|
+| 1        | 3_522   | 1% | 3_522     | 1%         |
+| 2        | 870     | 0% | 5_262     | 1%         |
+| 3        | 222     | 0% | 5_928     | 2%         |
+| 4        | 165     | 0% | 6_588     | 2%         |
+| 5        | 55      | 0% | 6_863     | 2%         |
+| 6        | 44      | 0% | 7_127     | 2%         |
+| 7        | 20      | 0% | 7_267     | 2%         |
+| 8        | 21      | 0% | 7_435     | 2%         |
+| 9        | 22      | 0% | 7_633     | 2%         |
+| 10       | 32      | 0% | 7_953     | 2%         |
+
+subterms: 363_160 bindings, 1_048_576 buckets, 0.35 bindings/bucket, max 178
+buckets with 0 bindings: 742_670 (70% of buckets)
+
+| bindings | buckets | %   | cumulated | % bindings |
+|----------|---------|-----|-----------|------------|
+| 1        | 255_762 | 70% | 255_762   | 70%        |
+| 2        | 44_486  | 24% | 344_734   | 94%        |
+| 3        | 5_130   | 4%  | 360_124   | 99%        |
+| 4        | 459     | 0%  | 361_960   | 99%        |
+| 5        | 32      | 0%  | 362_120   | 99%        |
+| 6        | 10      | 0%  | 362_180   | 99%        |
+| 7        | 4       | 0%  | 362_208   | 99%        |
+| 8        | 4       | 0%  | 362_240   | 99%        |
+| 9        | 0       | 0%  | 362_240   | 99%        |
+| 10       | 2       | 0%  | 362_260   | 99%        |
 
 ## 19/01/24
 

--- a/README.md
+++ b/README.md
@@ -421,8 +421,8 @@ Dumping of `hol.ml`:
   * purge time: 11s
   * unused proof steps after purge: 60%
 
-| rule         |  % |
-|:-------------|---:|
+| rule       |  % |
+|:-----------|---:|
 | comb       | 20 |
 | term_subst | 17 |
 | refl       | 16 |
@@ -444,12 +444,12 @@ Dumping of `hol.ml`:
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `split`:
   * make sti: <1s
-  * make -j32 lp: 42s 1.2G
-  * make mklp: 39s 2.7M
+  * make -j32 lp: 44s 1.2G
+  * make mklp: 36s 3.5M
   * make -j32 lpo: 1h36m 0.9G
-  * make -j32 v: 42s 1.1G
-  * make mkv: 41s 2.7M
-  * make -j16 vo: 32m20s 3.1G
+  * make -j32 v: 46s 1.1G
+  * make mkv: 32s 3.4M
+  * make -j16 vo: 40m29s 3.5G
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `mk 100`:
   * hol2dk mk 100: 14s

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `split`:
   * make -j32 lpo: 1h36m 0.9G
   * make -j32 v: 42s 1.1G
   * make mkv: 41s 2.7M
-  * make -j20 vo: 28m 3.1G
+  * make -j16 vo: 32m20s 3.1G
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `mk 100`:
   * hol2dk mk 100: 14s

--- a/README.md
+++ b/README.md
@@ -25,21 +25,22 @@ The HOL-Light base library `hol.ml` and the libraries `Arithmetic` and
 `Logic` formalizing the metatheory of first-order logic can be
 exported and translated to Dedukti, Lambdapi and Coq in a few
 minutes. The generated Dedukti files can be checked in a few minutes
-also, but it takes a much longer time for Coq to check the generated
-files (28 minutes for `hol.ml`), and too much memory for Lambdapi.
+also, but it takes a much longer time for Coq and Lambdapi to check
+the generated files (28 minutes for Coq for `hol.ml`).
 
 On the other hand, `hol2dk` may take several hours to translate the
 proofs of a few particular theorems of the `Multivariate` library:
-`GRASSMANN_PLUCKER_4`, `CHAIN_BOUNDARY_BOUNDARY` and
+`CHAIN_BOUNDARY_BOUNDARY`, `GRASSMANN_PLUCKER_4` and
 `HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS`, because their proofs
-contain a lot of big terms.
+contain a lot of big terms. For such files, one should use the option
+`--use-sharing` to reduce the size of generated files.
 
-Finally, while it is possible to translate any HOL-Light proof to Coq,
-the translated theorem may not be directly usable by Coq users because
-HOL-Light types and functions may not be aligned with those of the Coq
-standard library yet. Currently, only the type of natural numbers and
-various functions on natural numbers have been aligned. We gathered
-the obtained 448 lemmas in the package
+Finally, while it is a priori possible to translate any HOL-Light
+proof to Coq, the translated theorem may not be directly usable by Coq
+users because HOL-Light types and functions may not be aligned with
+those of the Coq standard library yet. Currently, only the type of
+natural numbers and various functions on natural numbers have been
+aligned. We gathered the obtained 448 lemmas in the package
 [coq-hol-light](https://github.com/Deducteam/coq-hol-light) available
 in the Coq Opam repository [released](https://github.com/coq/opam). We
 are working on adding more mappings (lists, reals).
@@ -209,7 +210,7 @@ Generating dk/lp files in parallel
 
 Dk/lp file generation is linear in the size of dumped files. For big
 dumped files, we provide two different commands to do file generation
-in parallel using `make`: `mk` and `split`. Currently, only `mk`
+in parallel using `make`: `split` and `mk`. Currently, only `mk`
 allows to generate dk files, but `split` generate lp and coq files
 that are faster to check.
 
@@ -241,6 +242,8 @@ make BASE=file -j $jobs vo # check v files
 ```
 
 Remark: you do not need to write `BASE=file` if the directory name is `file`.
+
+Remark: if you have big files, add them in the variable `FILES_WITH_SHARING` in `Makefile`.
 
 **By splitting proofs in several parts: command `mk`**
 
@@ -445,12 +448,12 @@ Dumping of `hol.ml`:
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `split`:
   * make sti: <1s
-  * make -j32 lp: 44s 1.2G
-  * make mklp: 36s 3.5M
-  * make -j32 lpo: 1h36m 0.9G
-  * make -j32 v: 46s 1.1G
-  * make mkv: 32s 3.4M
-  * make -j16 vo: 40m29s 3.5G
+  * make -j32 lp: 42s 1.1G (41s 1.2G with sharing)
+  * make mklp: 36s 2.7M (45s 3.5M with sharing)
+  * make -j16 lpo: 51m10s 9G
+  * make -j32 v: 45s 1.1G (47s 1.1G with sharing)
+  * make mkv: <1s 2.6M (3.4M with sharing)
+  * make -j16 vo: 31m35s 3.1G (40m37s 3.5G with sharing)
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `mk 100`:
   * hol2dk mk 100: 14s

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ mkdir -p ~/output-hol2dk/hol
 cd ~/output-hol2dk/hol
 $HOL2DK_DIR/add-links hol
 ```
-This will add links to files that are needed to generate, translate and check proofs.
+This will add links to files needed to generate, translate and check proofs.
 
 **By generating a lp file for each named theorem: command `split`**
 
@@ -239,6 +239,8 @@ make BASE=file -j $jobs v # generate v files
 make BASE=file mkv # generate coq.mk (v files dependencies)
 make BASE=file -j $jobs vo # check v files
 ```
+
+Remark: you do not need to write `BASE=file` if the directory name is `file`.
 
 **By splitting proofs in several parts: command `mk`**
 

--- a/README.md
+++ b/README.md
@@ -444,11 +444,11 @@ Dumping of `hol.ml`:
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `split`:
   * make sti: <1s
-  * make -j32 lp: 32s 1.1G, 40s with sharing
-  * make mklp: 47s 2.7M
+  * make -j32 lp: 45s 1.2G
+  * make mklp: 39s 2.7M
   * make -j32 lpo: 1h36m 0.9G
-  * make -j32 v: 43s 1.1G
-  * make mkv: 51s 2.7M
+  * make -j32 v: 44s 1.1G
+  * make mkv: 41s 2.7M
   * make -j20 vo: 28m 3.1G
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `mk 100`:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ On the other hand, `hol2dk` may take several hours to translate the
 proofs of a few particular theorems of the `Multivariate` library:
 `GRASSMANN_PLUCKER_4`, `CHAIN_BOUNDARY_BOUNDARY` and
 `HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS`, because their proofs
-contqin a lot of big terms and the lambdapi output does not use enough
-sharing. We will work on improving this.
+contain a lot of big terms without sharing. We will work on improving
+this.
 
 Finally, while it is possible to translate any HOL-Light proof to Coq,
 the translated theorem may not be directly usable by Coq users because
@@ -447,7 +447,7 @@ Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `split`:
   * make -j32 lp: 45s 1.2G
   * make mklp: 39s 2.7M
   * make -j32 lpo: 1h36m 0.9G
-  * make -j32 v: 44s 1.1G
+  * make -j32 v: 42s 1.1G
   * make mkv: 41s 2.7M
   * make -j20 vo: 28m 3.1G
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ On the other hand, `hol2dk` may take several hours to translate the
 proofs of a few particular theorems of the `Multivariate` library:
 `GRASSMANN_PLUCKER_4`, `CHAIN_BOUNDARY_BOUNDARY` and
 `HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS`, because their proofs
-contain a lot of big terms without sharing. We will work on improving
-this.
+contain a lot of big terms.
 
 Finally, while it is possible to translate any HOL-Light proof to Coq,
 the translated theorem may not be directly usable by Coq users because

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Dumping of `hol.ml`:
 
 Multi-threaded translation of `hol.ml` to Lambdapi and Coq with `split`:
   * make sti: <1s
-  * make -j32 lp: 45s 1.2G
+  * make -j32 lp: 42s 1.2G
   * make mklp: 39s 2.7M
   * make -j32 lpo: 1h36m 0.9G
   * make -j32 v: 42s 1.1G

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,10 @@
 TODO
 ----
 
+- remove/comment code for mk (i.e. use split as default)
+
+- remove the need to define BASE in Makefile
+
 - improve efficiency of code outputing dk/lp (avoid multiple term traversals)
 
 - generate lp.mk and coq.mk at the same time as lp files

--- a/TODO.md
+++ b/TODO.md
@@ -3,15 +3,11 @@ TODO
 
 - remove/comment code for mk (i.e. use split as default)
 
-- remove the need to define BASE in Makefile
-
 - improve efficiency of code outputing dk/lp (avoid multiple term traversals)
 
 - generate lp.mk and coq.mk at the same time as lp files
 
 - extend split command to dedukti output
-
-- add abbreviations for closed terms
 
 - get rid of use file? in pos files, set pos to -1 for unused theorems?
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 TODO
 ----
 
+- improve efficiency of code outputing dk/lp (avoid multiple term traversals)
+
 - generate lp.mk and coq.mk at the same time as lp files
 
 - extend split command to dedukti output

--- a/main.ml
+++ b/main.ml
@@ -341,12 +341,14 @@ let basename_ml f =
   | _ -> wrong_arg()
 
 let print_hstats() =
-  log "\nstring: %a\ntype: %a\nterm: %a\ntype_abbrev: %a\nterm_abbrev: %a"
+  log "\nstring: %a\ntype: %a\nterm: %a\ntype_abbrev: %a\nterm_abbrev: %a\
+       \nsubterms: %a"
     hstats (StrHashtbl.stats htbl_string)
     hstats (TypHashtbl.stats htbl_type)
     hstats (TrmHashtbl.stats htbl_term)
     hstats (TypHashtbl.stats htbl_type_abbrev)
     hstats (TrmHashtbl.stats htbl_term_abbrev)
+    hstats (TrmHashtbl.stats htbl_subterms)
 
 let rec log_command l =
   log "\nhol2dk"; List.iter (log " %s") l; log " ...\n"; command l

--- a/main.ml
+++ b/main.ml
@@ -125,22 +125,6 @@ hol2dk name
   in the working directory and all its subdirectories recursively
 %!"
 
-(*Experimental (not efficient)
-----------------------------
-
-hol2dk prf $x $y $file
-  generate a lp file for each proof from index $x to index $y in $file.prf
-  without using type and term abbreviations
-
-hol2dk mk-lp $jobs $file
-  generate Makefile.lp for generating with the option -j $jobs a lp file
-  (without type and term abbreviations) for each proof of $file.prf
-
-hol2dk mk-coq $n $file
-  generate a Makefile for translating to Coq each lp file generated
-  by Makefile.lp and check them by using $n sequential calls to make
-*)
-
 let wrong_arg() = Printf.eprintf "wrong argument(s)\n%!"; exit 1
 
 let is_dk filename =
@@ -871,40 +855,7 @@ and command = function
                         (n^"_deps.lp") (n^"_proofs.lp") (n^".lp")
                         (n^"_deps.lp") (n^"_proofs.lp"))
        end
-(*
-  | ["prf";x;y;b] ->
-     read_sig b;
-     read_pos b;
-     let x = integer x and y = integer y
-         and nb_proofs = Array.length !prf_pos in
-     if x < 0 || y < 0 || x > y || x >= nb_proofs || y >= nb_proofs then
-       wrong_arg();
-     init_proof_reading b;
-     read_use b;
-     Xlp.export_one_file_by_prf b x y;
-     close_in !Xproof.ic_prf;
-     0
 
-  | ["mk-lp";nb_parts;b] ->
-     let nb_parts = integer nb_parts in
-     if nb_parts < 1 then wrong_arg();
-     read_pos b;
-     let nb_proofs = Array.length !prf_pos in
-     init_proof_reading b;
-     Xlp.gen_lp_makefile_one_file_by_prf b nb_proofs nb_parts;
-     close_in !Xproof.ic_prf;
-     0
-
-  | ["mk-coq";nb_parts;b] ->
-     let nb_parts = integer nb_parts in
-     if nb_parts < 1 then wrong_arg();
-     read_pos b;
-     let nb_proofs = Array.length !prf_pos in
-     init_proof_reading b;
-     Xlp.gen_coq_makefile_one_file_by_prf b nb_proofs nb_parts;
-     close_in !Xproof.ic_prf;
-     0
- *)
   | f::args ->
      let r = range args in
      let dk = is_dk f in
@@ -956,3 +907,57 @@ and command = function
 let _ =
   (*Memtrace.trace_if_requested ();*)
   exit (command (List.tl (Array.to_list Sys.argv)))
+
+
+
+
+
+(*Experimental (not efficient)
+----------------------------
+
+hol2dk prf $x $y $file
+  generate a lp file for each proof from index $x to index $y in $file.prf
+  without using type and term abbreviations
+
+hol2dk mk-lp $jobs $file
+  generate Makefile.lp for generating with the option -j $jobs a lp file
+  (without type and term abbreviations) for each proof of $file.prf
+
+hol2dk mk-coq $n $file
+  generate a Makefile for translating to Coq each lp file generated
+  by Makefile.lp and check them by using $n sequential calls to make
+*)
+(*
+  | ["prf";x;y;b] ->
+     read_sig b;
+     read_pos b;
+     let x = integer x and y = integer y
+         and nb_proofs = Array.length !prf_pos in
+     if x < 0 || y < 0 || x > y || x >= nb_proofs || y >= nb_proofs then
+       wrong_arg();
+     init_proof_reading b;
+     read_use b;
+     Xlp.export_one_file_by_prf b x y;
+     close_in !Xproof.ic_prf;
+     0
+
+  | ["mk-lp";nb_parts;b] ->
+     let nb_parts = integer nb_parts in
+     if nb_parts < 1 then wrong_arg();
+     read_pos b;
+     let nb_proofs = Array.length !prf_pos in
+     init_proof_reading b;
+     Xlp.gen_lp_makefile_one_file_by_prf b nb_proofs nb_parts;
+     close_in !Xproof.ic_prf;
+     0
+
+  | ["mk-coq";nb_parts;b] ->
+     let nb_parts = integer nb_parts in
+     if nb_parts < 1 then wrong_arg();
+     read_pos b;
+     let nb_proofs = Array.length !prf_pos in
+     init_proof_reading b;
+     Xlp.gen_coq_makefile_one_file_by_prf b nb_proofs nb_parts;
+     close_in !Xproof.ic_prf;
+     0
+*)

--- a/main.ml
+++ b/main.ml
@@ -20,7 +20,9 @@ hol2dk options command arguments
 Options
 -------
 
---hstats: print statistics on hash tables at exit
+--use-sharing: define term abbreviations using sharing
+
+--print-stats: print statistics on hash tables at exit
 
 Dumping commands
 ----------------
@@ -353,6 +355,8 @@ and command = function
   | [] | ["-"|"--help"|"help"] -> usage(); 0
 
   | "--print-stats"::args -> at_exit print_hstats; command args
+
+  | "--use-sharing"::args -> use_sharing := true; command args
 
   | ["dep";f] ->
      let dg = dep_graph (files()) in

--- a/main.ml
+++ b/main.ml
@@ -340,6 +340,14 @@ let basename_ml f =
   | ".ml" | ".hl" -> Filename.chop_extension f
   | _ -> wrong_arg()
 
+let print_hstats() =
+  log "\nstring: %a\ntype: %a\nterm: %a\ntype_abbrev: %a\nterm_abbrev: %a"
+    hstats (StrHashtbl.stats htbl_string)
+    hstats (TypHashtbl.stats htbl_type)
+    hstats (TrmHashtbl.stats htbl_term)
+    hstats (TypHashtbl.stats htbl_type_abbrev)
+    hstats (TrmHashtbl.stats htbl_term_abbrev)
+
 let rec log_command l =
   log "\nhol2dk"; List.iter (log " %s") l; log " ...\n"; command l
 

--- a/renaming.lp
+++ b/renaming.lp
@@ -78,3 +78,15 @@ builtin "ltle" ≔ <<=;
 builtin "ltle_def" ≔ <<=_def;
 builtin "mapsto" ≔ vdash>;
 builtin "mapsto_def" ≔ vdash>_def;
+
+// Multivariate
+builtin "add_c" ≔ +_c;
+builtin "add_c_def" ≔ +_c_def;
+builtin "percent" ≔ %;
+builtin "percent_def" ≔ %_def;
+builtin "mul_c" ≔ *_c;
+builtin "mul_c_def" ≔ *_c_def;
+builtin "pow_c" ≔ ^_c;
+builtin "pow_c_def" ≔ ^_c_def;
+builtin "_at" ≔ at;
+builtin "_at_def" ≔ at_def;

--- a/xdk.ml
+++ b/xdk.ml
@@ -299,9 +299,9 @@ let rename tvs =
     | Const(_,b) ->
        let su = subst_missing_as_bool tvs b in
        if su = [] then t else inst su t
-    | Comb(u,v) -> mk_comb(rename rmap u, rename rmap v)
+    | Comb(u,v) -> Comb(rename rmap u, rename rmap v)
     | Abs(u,v) ->
-       let rmap' = add_var rmap u in mk_abs(rename rmap' u,rename rmap' v)
+       let rmap' = add_var rmap u in Abs(rename rmap' u,rename rmap' v)
   in rename
 ;;
 

--- a/xlib.ml
+++ b/xlib.ml
@@ -875,9 +875,9 @@ let share_subterm =
   let idx = ref (-1) in
   fun l t ->
   (*log "share_subterm %a %a\n" (olist (opair oterm oterm)) !l oterm t;*)
-  try let (_,t') as x = TrmHashtbl.find htbl_subterms t in
+  try let (t,t') as x = TrmHashtbl.find htbl_subterms t in
       (*log "found\n";*)
-      if t <> t' && List.for_all ((<>) x) !l then
+      if t != t' && List.for_all ((!=) x) !l then
         begin l := x::!l; (*log "add let %a\n" (opair oterm oterm) x*) end;
       t'
   with Not_found ->

--- a/xlib.ml
+++ b/xlib.ml
@@ -949,6 +949,8 @@ let shared t =
   t', List.rev !l
 ;;
 
+let use_sharing = ref false;;
+
 (****************************************************************************)
 (* Type and term abbreviations to reduce size of generated files. *)
 (****************************************************************************)

--- a/xlp.ml
+++ b/xlp.ml
@@ -260,9 +260,9 @@ let rec rename rmap t =
   match t with
   | Var(_,b) -> (try mk_var(List.assoc t rmap,b) with Not_found -> mk_el b)
   | Const(_,_) -> t
-  | Comb(u,v) -> mk_comb(rename rmap u, rename rmap v)
+  | Comb(u,v) -> Comb(rename rmap u, rename rmap v)
   | Abs(u,v) ->
-     let rmap' = add_var rmap u in mk_abs(rename rmap' u,rename rmap' v)
+     let rmap' = add_var rmap u in Abs(rename rmap' u,rename rmap' v)
 ;;
 
 let term rmap oc t = abbrev_term oc (rename rmap t);;

--- a/xlp.ml
+++ b/xlp.ml
@@ -625,13 +625,15 @@ let export_term_abbrevs b n s =
   export n (s ^ "_term_abbrevs")
     (fun oc ->
       List.iter (require oc b) ["_types"; "_terms"];
-      List.iter (require oc n) [s ^ "_type_abbrevs"; s ^ "_subterm_abbrevs"];
+      require oc n (s ^ "_type_abbrevs");
+      if !use_sharing then require oc n (s ^ "_subterm_abbrevs");
       decl_term_abbrevs oc);
-  export n (s ^ "_subterm_abbrevs")
-    (fun oc ->
-      List.iter (require oc b) ["_types"; "_terms"];
-      List.iter (require oc n) [s ^ "_type_abbrevs"];
-      decl_subterm_abbrevs oc)
+  if !use_sharing then
+    export n (s ^ "_subterm_abbrevs")
+      (fun oc ->
+        List.iter (require oc b) ["_types"; "_terms"];
+        require oc n (s ^ "_type_abbrevs");
+        decl_subterm_abbrevs oc)
 ;;
 
 let export_axioms b =

--- a/xlp.ml
+++ b/xlp.ml
@@ -20,7 +20,7 @@ let name =
     ; "|-", "vdash"
     ; "|=>", "bar_imp"]
   in
-  fun oc n -> if n = "_" then log "underscore\n%!";
+  fun oc n ->
   string oc
     begin match n with
     | "" -> assert false


### PR DESCRIPTION
- use hash tables instead of maps to build abbreviations maps
- use sharing when building canonical types and terms
- add option --use-sharing for using sharing in lp output when defining term abbreviations
- fix valid dedukti and lambdapi identifiers
- add renamings for Multivariate

| term_abbrevs.lp file                    | generation | size w/o sharing | size w/ sharing | %    |
|-----------------------------------------|------------|------------------|-----------------|------|
| CHAIN_BOUNDARY_BOUNDARY                 | 56m29s     | 5.2G             | 1.9G            | -63% |
| GRASSMANN_PLUCKER_4                     | 3h25m27s   | 14G              | 4.7G            | -66% |
| HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS | 6h48m57s   | 19G              | 5.3G            | -72% |
