### PR TITLE
fix #86 + remove commands for one file by proof

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           eval `opam env`
           cp xci.ml hol-light/
           cd hol-light
-          hol2dk dump-use-simp xci.ml
+          hol2dk dump-simp-use xci.ml
       - name: Generate and check single-threaded dk output
         run: |
           eval `opam env`

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(BASE_FILES:%=%.lp) &:
 lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp)
 
 %.lp: %.sti
-	hol2dk --sharing theorem $(BASE) $@
+	hol2dk theorem $(BASE) $@
 
 .PHONY: clean-lp
 clean-lp:

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ WARNING: it is important to run the command in the HOL-Light directory so as to 
 For dumping (a subset of) `hol.ml` do:
 ```
 cd $HOLLIGHT_DIR
-hol2dk dump-use-simp file.ml
+hol2dk dump-simp-use file.ml
 ```
 where `file.ml` should at least contain the contents of `hol.ml` until the line `loads "fusion.ml";;`.
 
-The command `dump-simp` (and similarly for `dump-use-simp`) are actually the sequential composition of various lower level commands: `dump`, `pos`, `use`, `rewrite` and `purge`:
+The command `dump-simp` (and similarly for `dump-simp-use`) are actually the sequential composition of various lower level commands: `dump`, `pos`, `use`, `rewrite` and `purge`:
 
 **Simplifying dumped proofs.** HOL-Light proofs have many detours that can be simplified following simple rewrite rules. For instance, s(u)=s(u) is sometimes proved by MK_COMB from s=s and u=u, while it can be directly proved by REFL.
 
@@ -217,7 +217,7 @@ that are faster to check.
 Remark: for not cluttering HOL-Light sources with generated files, we suggest to proceed as follows. For instance, for generating the proofs for `hol.ml`:
 ```
 cd $HOLLIGHT_DIR
-hol2dk dump-use-simp hol.ml
+hol2dk dump-simp-use hol.ml
 mkdir -p ~/output-hol2dk/hol
 cd ~/output-hol2dk/hol
 $HOL2DK_DIR/add-links hol

--- a/main.ml
+++ b/main.ml
@@ -20,7 +20,6 @@ hol2dk options command arguments
 Options
 -------
 
---sharing: use sharing for recording term abbreviations
 --hstats: print statistics on hash tables at exit
 
 Dumping commands
@@ -124,8 +123,9 @@ hol2dk name upto file.[ml|hl]
 hol2dk name
   print on stdout the named theorems proved in all HOL-Light files
   in the working directory and all its subdirectories recursively
+%!"
 
-Experimental (not efficient)
+(*Experimental (not efficient)
 ----------------------------
 
 hol2dk prf $x $y $file
@@ -139,7 +139,7 @@ hol2dk mk-lp $jobs $file
 hol2dk mk-coq $n $file
   generate a Makefile for translating to Coq each lp file generated
   by Makefile.lp and check them by using $n sequential calls to make
-%!"
+*)
 
 let wrong_arg() = Printf.eprintf "wrong argument(s)\n%!"; exit 1
 
@@ -357,8 +357,6 @@ and dump_and_simp after_hol f =
 
 and command = function
   | [] | ["-"|"--help"|"help"] -> usage(); 0
-
-  | "--sharing"::args -> sharing := true; command args
 
   | "--print-stats"::args -> at_exit print_hstats; command args
 
@@ -863,7 +861,7 @@ and command = function
                         (n^"_deps.lp") (n^"_proofs.lp") (n^".lp")
                         (n^"_deps.lp") (n^"_proofs.lp"))
        end
-
+(*
   | ["prf";x;y;b] ->
      read_sig b;
      read_pos b;
@@ -896,7 +894,7 @@ and command = function
      Xlp.gen_coq_makefile_one_file_by_prf b nb_proofs nb_parts;
      close_in !Xproof.ic_prf;
      0
-
+ *)
   | f::args ->
      let r = range args in
      let dk = is_dk f in

--- a/main.ml
+++ b/main.ml
@@ -29,7 +29,7 @@ hol2dk dump-simp $file.[ml|hl]
   compose the commands dump, pos, use, rewrite and purge
   for $file depending on hol.ml
 
-hol2dk dump-use-simp $file.[ml|hl]
+hol2dk dump-simp-use $file.[ml|hl]
   same as hol2dk dump except that hol.ml is not loaded first
 
 hol2dk dump $file.[ml|hl]
@@ -389,7 +389,7 @@ and command = function
   | ["dump";f] -> dump true f (basename_ml f)
   | ["dump-use";f] -> dump false f (basename_ml f)
   | ["dump-simp";f] -> dump_and_simp true f
-  | ["dump-use-simp";f] -> dump_and_simp false f
+  | ["dump-simp-use";f] -> dump_and_simp false f
 
   | ["pos";b] ->
      let nb_proofs = read_val (b ^ ".nbp") in

--- a/xdk.ml
+++ b/xdk.ml
@@ -12,11 +12,17 @@ open Xproof
 (****************************************************************************)
 
 (* Dedukti valid identifiers *)
-let is_alpha = function 'a'..'z' | 'A'..'Z' | '0'..'9' -> true | _ -> false;;
-let is_valid_letter = function
-  | '_' | '\'' | 'a'..'z' | 'A'..'Z' | '0'..'9' -> true | _ -> false;;
+let is_valid_first_letter = function
+  | 'a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '!' | '?' -> true
+  | _ -> false;;
+let is_valid_non_first_letter = function
+  | 'a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '!' | '?' | '\'' -> true
+  | _ -> false;;
 let is_valid_id s =
-  s <> "" && is_alpha s.[0] && String.for_all is_valid_letter s;;
+  String.for_all is_valid_non_first_letter s
+  && s <> ""
+  && s.[0] <> '\''
+  && s <> "_";;
 
 (* We rename some symbols to make files smaller and more readable. *)
 let valid_name = function

--- a/xdk.ml
+++ b/xdk.ml
@@ -115,16 +115,7 @@ let abbrev_typ =
      | _ -> out oc "(%a%a)" typ_abbrev k (list_prefix " " raw_typ) tvs
 ;;
 
-(*let typ =
-  (*if !use_abbrev then*)
-  fun tvs oc b -> abbrev_typ oc (missing_as_bool tvs b)
-  (*else unabbrev_typ*)
-;;*)
-
-let typ ?(abbrev=true) tvs oc b =
-  if abbrev then abbrev_typ oc (missing_as_bool tvs b)
-  else unabbrev_typ tvs oc b
-;;
+let typ tvs oc b = abbrev_typ oc (missing_as_bool tvs b);;
 
 (* [decl_map_typ oc] outputs on [oc] the type abbreviations. *)
 let decl_map_typ oc =
@@ -308,11 +299,10 @@ let rename tvs =
   in rename
 ;;
 
-let term =
-  (*if !use_abbrev then*)
-    fun tvs rmap oc t -> abbrev_term tvs oc (rename tvs rmap t)
-  (*else unabbrev_term*)
-;;
+(* [term tvs rmap oc t] prints on [oc] the term [t] with type
+   variables [tvs] and term variable renaming map [rmap]. A variable
+   of type [b] not in [rmap] is replaced by [el b]. *)
+let term tvs rmap oc t = abbrev_term tvs oc (rename tvs rmap t);;
 
 (* [decl_map_term oc] outputs on [oc] the term abbreviations. *)
 let decl_map_term oc =

--- a/xlib.ml
+++ b/xlib.ml
@@ -287,15 +287,15 @@ let type_var =
     else (log "a_max = %d\n%!" i; hmk_vartype ("a" ^ string_of_int i))
   in v, tv
 ;;
-
+(*
 (* Without sharing, [canonical_typ b] returns the type variables of
    [b] together with a type alpha-equivalent to [b] such that, for any
    type [b'] alpha-equivalent to [b], [canonical_typ b' =
    canonical_typ b]. *)
-let _canonical_typ b =
+let canonical_typ b =
   let tvs = tyvars b in tvs, type_subst (List.mapi type_var tvs) b
 ;;
-
+ *)
 (* With sharing, [canonical_typ b] returns the type variables of [b]
    together with a type alpha-equivalent to [b] such that, for any
    type [b'] alpha-equivalent to [b], [canonical_typ b' =
@@ -517,12 +517,12 @@ let term_var =
      in v, hmk_var(s,b)
   | _ -> assert false
 ;;
-
+(*
 (* [canonical_term t] returns the free type and term variables of [t]
    together with a term alpha-equivalent to [t] so that
    [canonical_term t = canonical_term u] if [t] and [u] are
    alpha-equivalent. *)
-let _canonical_term =
+let canonical_term =
   (*let a_max = ref 0 and x_max = ref 0 and y_max = ref 0 in*)
   let sy = Array.init 50 (fun i -> "y" ^ string_of_int i) in
   (* [subst i su t] applies [su] on [t] and rename abstracted
@@ -551,7 +551,7 @@ let _canonical_term =
   let bs = List.map get_vartype vs' and su' = List.mapi term_var vs' in
   tvs, vs, bs, subst 0 su' t'
 ;;
-
+ *)
 (****************************************************************************)
 (* Canonical term for alpha-equivalence with sharing. *)
 (****************************************************************************)

--- a/xlib.ml
+++ b/xlib.ml
@@ -171,8 +171,6 @@ let hstats oc hs =
 (* Sharing of strings, types and terms. *)
 (****************************************************************************)
 
-let sharing = ref false;;
-
 module StrHash = struct
   type t = string
   let equal x1 x2 = x1 == x2 || x1 = x2
@@ -272,11 +270,11 @@ let tyvars b = List.sort_uniq compare (tyvars b);;
 (* [missing_as_bool tvs b] replaces in [b] every type variable not in
    [tvs]. *)
 let missing_as_bool tvs =
-  let rec typ b =
+  let rec aux b =
     match b with
     | Tyvar _ -> if List.mem b tvs then b else bool_ty
-    | Tyapp(n,bs) -> mk_type(n, List.map typ bs)
-  in typ
+    | Tyapp(n,bs) -> mk_type(n, List.map aux bs)
+  in aux
 ;;
 
 (* [type_var i tv] returns [v, tv] where [v] is the type variable of
@@ -294,15 +292,15 @@ let type_var =
    [b] together with a type alpha-equivalent to [b] such that, for any
    type [b'] alpha-equivalent to [b], [canonical_typ b' =
    canonical_typ b]. *)
-let canonical_typ b =
+let _canonical_typ b =
   let tvs = tyvars b in tvs, type_subst (List.mapi type_var tvs) b
 ;;
 
-(* With sharing, [hcanonical_typ b] returns the type variables of [b]
+(* With sharing, [canonical_typ b] returns the type variables of [b]
    together with a type alpha-equivalent to [b] such that, for any
    type [b'] alpha-equivalent to [b], [canonical_typ b' =
    canonical_typ b]. *)
-let hcanonical_typ =
+let canonical_typ =
   let rec type_subst s b =
     match b with
     | Tyapp(c,bs) -> hmk_tyapp (c, List.map (type_subst s) bs)
@@ -311,9 +309,6 @@ let hcanonical_typ =
   fun b ->
   let tvs = tyvars b in tvs, type_subst (List.mapi type_var tvs) b
 ;;
-
-let canonical_typ b =
-  if !sharing then hcanonical_typ b else canonical_typ b;;
 
 (* Subterm positions in types are represented as list of natural numbers. *)
 
@@ -527,7 +522,7 @@ let term_var =
    together with a term alpha-equivalent to [t] so that
    [canonical_term t = canonical_term u] if [t] and [u] are
    alpha-equivalent. *)
-let canonical_term =
+let _canonical_term =
   (*let a_max = ref 0 and x_max = ref 0 and y_max = ref 0 in*)
   let sy = Array.init 50 (fun i -> "y" ^ string_of_int i) in
   (* [subst i su t] applies [su] on [t] and rename abstracted
@@ -561,11 +556,11 @@ let canonical_term =
 (* Canonical term for alpha-equivalence with sharing. *)
 (****************************************************************************)
 
-(* [hcanonical_term t] returns the free type and term variables of [t]
+(* [canonical_term t] returns the free type and term variables of [t]
    together with a term alpha-equivalent to [t] so that
-   [hcanonical_term t = hcanonical_term u] if [t] and [u] are
+   [canonical_term t = canonical_term u] if [t] and [u] are
    alpha-equivalent. *)
-let hcanonical_term =
+let canonical_term =
   (*let a_max = ref 0 and x_max = ref 0 and y_max = ref 0 in*)
   let sy = Array.init 50 (fun i -> "y" ^ string_of_int i) in
   (* [subst i su t] applies [su] on [t] and rename abstracted
@@ -594,9 +589,6 @@ let hcanonical_term =
   let bs = List.map get_vartype vs' and su' = List.mapi term_var vs' in
   tvs, vs, bs, subst 0 su' t'
 ;;
-
-let canonical_term t =
-  if !sharing then hcanonical_term t else canonical_term t;;
 
 (****************************************************************************)
 (* Functions on proofs. *)

--- a/xlp.ml
+++ b/xlp.ml
@@ -104,7 +104,8 @@ let abbrev_typ =
      | _ -> out oc "(type%d%a)" k (list_prefix " " raw_typ) tvs
 ;;
 
-let typ oc b = if !use_abbrev then abbrev_typ oc b else raw_typ oc b;;
+let typ oc b = abbrev_typ oc b;;
+  (*if !use_abbrev then abbrev_typ oc b else raw_typ oc b;;*)
 
 (* [decl_map_typ oc] outputs on [oc] the type abbreviations. *)
 let decl_map_typ oc =
@@ -264,10 +265,9 @@ let rec rename rmap t =
      let rmap' = add_var rmap u in mk_abs(rename rmap' u,rename rmap' v)
 ;;
 
-let term rmap oc t =
-  if !use_abbrev then abbrev_term oc (rename rmap t)
-  else unabbrev_term rmap oc (rename rmap t)
-;;
+let term rmap oc t = abbrev_term oc (rename rmap t);;
+  (*if !use_abbrev then abbrev_term oc (rename rmap t)
+  else unabbrev_term rmap oc (rename rmap t);;*)
 
 (* [decl_map_term oc] outputs on [oc] the term abbreviations. *)
 let decl_map_term oc =
@@ -672,7 +672,7 @@ let export_theorems_part k b map_thid_name =
       for i = 1 to k do require oc b ("_part_" ^ string_of_int i) done;
       out_map_thid_name false oc map_thid_name)
 ;;
-
+(*
 (****************************************************************************)
 (* Generate a lp file without abbreviations for each proof step. *)
 (****************************************************************************)
@@ -809,3 +809,4 @@ let gen_coq_makefile_one_file_by_prf b nb_proofs nb_parts =
           \trm -f *.glob *.vo* .*.aux *.lpo *.dko\n";
   close_out oc
 ;;
+*)

--- a/xlp.ml
+++ b/xlp.ml
@@ -104,7 +104,7 @@ let abbrev_typ =
      | _ -> out oc "(type%d%a)" k (list_prefix " " raw_typ) tvs
 ;;
 
-let typ oc b = abbrev_typ oc b;;
+let typ = abbrev_typ;;
   (*if !use_abbrev then abbrev_typ oc b else raw_typ oc b;;*)
 
 (* [decl_map_typ oc] outputs on [oc] the type abbreviations. *)


### PR DESCRIPTION
- fix #86 (abbreviations duplication)
- remove option --sharing and always use sharing
- remove commands for one file by proof
- rename command dump-use-simp into dump-simp-use
- fix #87 (valid dedukti identifiers checking)