### PR TITLE
generate lpo and vo dependencies for make

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,6 @@ jobs:
           make split
           make -j3 lp
           make -j3 v
-          #make dep
           make -j3 lpo
       - name: Check resizing
         run: |
@@ -108,17 +107,12 @@ jobs:
           hol2dk link xci
           make split
           make -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
-          #make dep
           make -j3 lpo
           hol2dk resize thm75360.lp 500
-          #make dep
           make -j3 lpo
           hol2dk resize thm75360.lp 100
-          #make dep
           make -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 300
-          #make dep
           make -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 100
-          #make dep
           make -j3 lpo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
           make split
           make -j3 lp
           make -j3 v
-          make dep
+          #make dep
           make -j3 lpo
       - name: Check resizing
         run: |
@@ -108,17 +108,17 @@ jobs:
           hol2dk link xci
           make split
           make -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
-          make dep
+          #make dep
           make -j3 lpo
           hol2dk resize thm75360.lp 500
-          make recompute-deps
+          #make dep
           make -j3 lpo
           hol2dk resize thm75360.lp 100
-          make recompute-deps
+          #make dep
           make -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 300
-          make recompute-deps
+          #make dep
           make -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 100
-          make recompute-deps
+          #make dep
           make -j3 lpo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,14 +111,14 @@ jobs:
           make dep
           make -j3 lpo
           hol2dk resize thm75360.lp 500
-          make dep
+          make recompute-deps
           make -j3 lpo
           hol2dk resize thm75360.lp 100
-          make dep
+          make recompute-deps
           make -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 300
-          make dep
+          make recompute-deps
           make -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 100
-          make dep
+          make recompute-deps
           make -j3 lpo

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,11 @@ clean-opam:
 	rm -f $(BASE)_opam.*
 
 .PHONY: clean-all
-clean-all: clean-split clean-lp clean-dep-lpo clean-lpo clean-v clean-dep-vo clean-vo clean-opam
+clean-all: clean-split clean-lp clean-dep-lpo clean-lpo clean-v clean-dep-vo clean-vo clean-opam clean-mk
+
+.PHONY: clean-mk
+clean-mk:
+	find . -maxdepth 1 -name '*.lpo.mk' -delete
 
 .PHONY: all
 all:

--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,15 @@ clean-lp: clean-lpo clean-v clean-vo
 
 include lpo.mk
 
-lpo.mk:
-	touch $@
+LP_FILES := $(wildcard *.lp)
 
 .PHONY: dep-lpo
-dep-lpo:
-	echo 'theory_hol.lpo:' > lpo.mk
-	cat *.lpo.mk >> lpo.mk
+dep-lpo: lpo.mk
+lpo.mk: $(LP_FILES:%.lp=%.lpo.mk)
+	cat *.lpo.mk > lpo.mk
+
+theory_hol.lpo.mk: theory_hol.lp
+	$(HOL2DK_DIR)/dep-lpo $< > $@
 
 .PHONY: recompute-deps
 recompute-deps:
@@ -63,8 +65,6 @@ recompute-deps:
 .PHONY: clean-dep-lpo
 clean-dep-lpo:
 	rm -f lpo.mk
-
-LP_FILES := $(wildcard *.lp)
 
 .PHONY: lpo
 lpo: $(LP_FILES:%.lp=%.lpo)
@@ -88,14 +88,12 @@ clean-v: clean-vo
 	find . -maxdepth 1 -name '*.v' -a ! -name coq.v -delete
 
 .PHONY: dep-vo
-dep-vo: lpo.mk
+dep-vo: vo.mk
+vo.mk: lpo.mk
 	sed -e 's/\.lpo/.vo/g' -e 's/: theory_hol.vo/: coq.vo theory_hol.vo/' -e 's/theory_hol.vo:/theory_hol.vo: coq.vo/' lpo.mk > vo.mk
 #find . -maxdepth 1 -name '*.v' -exec $(HOL2DK_DIR)/dep-vo {} \; > vo.mk
 
 include vo.mk
-
-vo.mk:
-	touch $@
 
 .PHONY: clean-dep-vo
 clean-dep-vo:

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,13 @@ lpo.mk:
 
 .PHONY: dep-lpo
 dep-lpo:
-	cat *.lpo.mk > lpo.mk
-#	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lpo {} \; > lpo.mk
+	echo 'theory_hol.lpo:' > lpo.mk
+	cat *.lpo.mk >> lpo.mk
+
+.PHONY: recompute-deps
+recompute-deps:
+	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lpo {} \; > lpo.mk
+	$(MAKE) dep-vo
 
 .PHONY: clean-dep-lpo
 clean-dep-lpo:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ lpo.mk:
 
 .PHONY: dep-lpo
 dep-lpo:
-	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lpo {} \; > lpo.mk
+	cat *.lpo.mk > lpo.mk
+#	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lpo {} \; > lpo.mk
 
 .PHONY: clean-dep-lpo
 clean-dep-lpo:

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,7 @@ STI_FILES := $(wildcard *.sti)
 
 .PHONY: default
 default:
-	@echo "targets: split lp dep lpo v vo opam clean-<target> clean-all"
-
-.PHONY: dep
-dep: dep-lpo dep-vo
-
-.PHONY: clean-dep
-clean-dep: clean-dep-lpo clean-dep-vo
+	@echo "targets: split lp lpo v vo opam clean-<target> clean-all"
 
 .PHONY: split
 split:
@@ -49,22 +43,12 @@ include lpo.mk
 
 LP_FILES := $(wildcard *.lp)
 
-.PHONY: dep-lpo
-dep-lpo: lpo.mk
 lpo.mk: $(LP_FILES:%.lp=%.lpo.mk)
 	cat *.lpo.mk > lpo.mk
+#	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lpo {} \; > lpo.mk
 
 theory_hol.lpo.mk: theory_hol.lp
 	$(HOL2DK_DIR)/dep-lpo $< > $@
-
-.PHONY: recompute-deps
-recompute-deps:
-	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lpo {} \; > lpo.mk
-	$(MAKE) dep-vo
-
-.PHONY: clean-dep-lpo
-clean-dep-lpo:
-	rm -f lpo.mk
 
 .PHONY: lpo
 lpo: $(LP_FILES:%.lp=%.lpo)
@@ -87,17 +71,11 @@ v: $(LP_FILES:%.lp=%.v)
 clean-v: clean-vo
 	find . -maxdepth 1 -name '*.v' -a ! -name coq.v -delete
 
-.PHONY: dep-vo
-dep-vo: vo.mk
 vo.mk: lpo.mk
 	sed -e 's/\.lpo/.vo/g' -e 's/: theory_hol.vo/: coq.vo theory_hol.vo/' -e 's/theory_hol.vo:/theory_hol.vo: coq.vo/' lpo.mk > vo.mk
-#find . -maxdepth 1 -name '*.v' -exec $(HOL2DK_DIR)/dep-vo {} \; > vo.mk
+#	find . -maxdepth 1 -name '*.v' -exec $(HOL2DK_DIR)/dep-vo {} \; > vo.mk
 
 include vo.mk
-
-.PHONY: clean-dep-vo
-clean-dep-vo:
-	rm -f vo.mk
 
 .PHONY: vo
 vo: $(LP_FILES:%.lp=%.vo)
@@ -127,19 +105,18 @@ clean-opam:
 	rm -f $(BASE)_opam.*
 
 .PHONY: clean-all
-clean-all: clean-split clean-lp clean-dep-lpo clean-lpo clean-v clean-dep-vo clean-vo clean-opam clean-mk
+clean-all: clean-split clean-lp clean-lpo clean-v clean-vo clean-opam clean-mk
 
 .PHONY: clean-mk
 clean-mk:
 	find . -maxdepth 1 -name '*.lpo.mk' -delete
+	rm -f lpo.mk vo.mk
 
 .PHONY: all
 all:
 	$(MAKE) clean-all
 	$(MAKE) split
 	$(MAKE) lp
-	$(MAKE) dep-lpo
 	$(MAKE) lpo
 	$(MAKE) v
-	$(MAKE) dep-vo
 	$(MAKE) vo

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,13 @@
 NOTES
 -----
 
+## 07/03/24
+
+  * URYSOHN_LEMMA*.vo: --max-size 500000 --max-abbrevs 250 -j16 ~20m
+  * CHAIN_BOUNDARY_BOUNDARY*.vo: --max-size 500000 --max-abbrevs 250 -j16 ~120m
+  * GRASSMANN_PLUCKER_4: --max-size 20000 --max-abbrevs 100 -j1 ~40m
+  * HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS: --max-size 20000 --max-abbrevs 250
+
 ## 06/03/24
 
   * CHAIN_BOUNDARY_BOUNDARY.lp: 38m50s

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,14 @@
 NOTES
 -----
 
+## 11/03/24
+
+generation of .lpo.mk files:
+
+hol.ml:
+  - without generation: make -j32 lp 47s dep-lpo 42s
+  - with generation: make -j32 lp 46s dep-lpo 0.4s
+
 ## 07/03/24
 
   * URYSOHN_LEMMA*.vo: --max-size 500000 --max-abbrevs 250 -j16 ~20m

--- a/NOTES.md
+++ b/NOTES.md
@@ -6,7 +6,7 @@ NOTES
   * URYSOHN_LEMMA*.vo: --max-size 500000 --max-abbrevs 250 -j16 ~20m
   * CHAIN_BOUNDARY_BOUNDARY*.vo: --max-size 500000 --max-abbrevs 250 -j16 ~120m
   * GRASSMANN_PLUCKER_4: --max-size 20000 --max-abbrevs 100 -j1 ~40m
-  * HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS: --max-size 20000 --max-abbrevs 250
+  * HOMOTOPIC_IMP_HOMOLOGOUS_REL_CHAIN_MAPS: --max-size 20000 --max-abbrevs 250 out of memory
 
 ## 06/03/24
 

--- a/README.md
+++ b/README.md
@@ -253,11 +253,10 @@ After `hol2dk link`, you can use `make -j$jobs TARGET` to translate and check fi
 - `split` to do `hol2dk split`
 - `lp` to generate lp files
 - `v` to translate lp files to Coq
-- `dep` to generate dependencies to check lp or v files in parallel
 - `lpo` to check lp files
 - `vo` to check Coq files
 
-The order of targets is important: `split` must be done first, `v` will do `lp`, and `dep` must be done after `lp` and before `lpo` or `vo`.
+The order of targets is important: `split` must be done first and `lp` second.
 
 You can also write in a file called `FILES_WITH_SHARING` a space-separated list of theorem names for which sharing is needed.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,15 @@
 TODO
 ----
 
+- name lemmas with prefix "lem" instead of "thm_"
+
+- split abbrevs according to size, not number
+
 - generate proof parts in parallel like with hol2dk mk
 
 - generate term_abbrevs parts in parallel by dumping the htable and then reading the dumped list in parallel
+
+- optimize dependencies of a proof part wrt term abbrevs by defining term abbrevs in order and recording the term abbrevs used by each proof part
 
 - optimize number of let's (use a let only if an abbreviation is used more than once)
 

--- a/TODO.md
+++ b/TODO.md
@@ -35,8 +35,6 @@ TODO
 
 - improve efficiency of code outputing dk/lp (avoid multiple term traversals)
 
-- generate lp.mk and coq.mk at the same time as lp files
-
 - extend split command to dedukti output
 
 - get rid of use file? in pos files, set pos to -1 for unused theorems?

--- a/TODO.md
+++ b/TODO.md
@@ -31,7 +31,7 @@ TODO
 
 - remove the need for sed after lambdapi export -o stt_coq
 
-- remove/comment code for mk (i.e. use split as default)
+- remove/comment code for mk? (i.e. use split as default)
 
 - improve efficiency of code outputing dk/lp (avoid multiple term traversals)
 

--- a/main.ml
+++ b/main.ml
@@ -117,6 +117,12 @@ hol2dk env
 hol2dk nbp $file
   print the number of proof steps in $file.prf
 
+hol2dk resize $file_term_abbrevs.lp $n
+  rebuild the term abbreviation files of $file.lp with --max-abbrevs $n
+
+hol2dk resize $file.lp $n
+  rebuild the proof files of $file.lp with --max-steps $n
+
 hol2dk proof $file $x $y
   print proof steps between theorem indexes $x and $y
 

--- a/main.ml
+++ b/main.ml
@@ -895,7 +895,7 @@ and command = function
        begin
          Xlp.export_theorem_proof n;
          close_in !Xproof.ic_prf;
-         Xlp.new_export_term_abbrevs b n;
+         Xlp.export_theorem_term_abbrevs b n;
          Xlp.export_theorem_deps b n;
          Xlp.export_type_abbrevs b n;
          0
@@ -941,7 +941,7 @@ and command = function
        end
      else
        begin
-         Xlp.export_proofs b b r;
+         Xlp.export_proofs b r;
          if r = All then Xlp.export_theorems b (read_val (b ^ ".thm"));
          Xlp.export_term_abbrevs b b;
          Xlp.export_type_abbrevs b b

--- a/main.ml
+++ b/main.ml
@@ -820,22 +820,21 @@ and command = function
      let k = integer k and x = integer x and y = integer y in
      if k < 1 || k > nb_parts || x < 0 || y < x then wrong_arg();
      read_sig b;
-     let suffix = "_part_" ^ string_of_int k in
      read_pos b;
      init_proof_reading b;
      read_use b;
      if is_dk f then
        begin
          Xdk.export_proofs_part b k x y;
-         Xdk.export_term_abbrevs b suffix;
-         Xdk.export_type_abbrevs b suffix
+         Xdk.export_term_abbrevs b (b^part k);
+         Xdk.export_type_abbrevs b (b^part k)
        end
      else
        begin
          let dg = input_value ic in
          Xlp.export_proofs_part b dg k x y;
-         Xlp.export_term_abbrevs b b suffix;
-         Xlp.export_type_abbrevs b b suffix
+         Xlp.export_term_abbrevs b (b^part k);
+         Xlp.export_type_abbrevs b (b^part k)
        end;
      close_in ic;
      close_in !Xproof.ic_prf;
@@ -898,7 +897,7 @@ and command = function
          close_in !Xproof.ic_prf;
          Xlp.new_export_term_abbrevs b n;
          Xlp.export_theorem_deps b n;
-         Xlp.export_type_abbrevs b n "";
+         Xlp.export_type_abbrevs b n;
          0
        end
 
@@ -944,8 +943,8 @@ and command = function
        begin
          Xlp.export_proofs b b r;
          if r = All then Xlp.export_theorems b (read_val (b ^ ".thm"));
-         Xlp.export_term_abbrevs b b "";
-         Xlp.export_type_abbrevs b b ""
+         Xlp.export_term_abbrevs b b;
+         Xlp.export_type_abbrevs b b
        end;
      close_in !Xproof.ic_prf;
      0

--- a/main.ml
+++ b/main.ml
@@ -826,8 +826,8 @@ and command = function
      if is_dk f then
        begin
          Xdk.export_proofs_part b k x y;
-         Xdk.export_term_abbrevs b (b^part k);
-         Xdk.export_type_abbrevs b (b^part k)
+         Xdk.export_term_abbrevs (b^part k);
+         Xdk.export_type_abbrevs (b^part k)
        end
      else
        begin
@@ -926,8 +926,8 @@ and command = function
        begin
          Xdk.export_proofs b r;
          if r = All then Xdk.export_theorems b (read_val (b ^ ".thm"));
-         Xdk.export_term_abbrevs b "";
-         Xdk.export_type_abbrevs b "";
+         Xdk.export_term_abbrevs b;
+         Xdk.export_type_abbrevs b;
          log "generate %s.dk ...\n%!" b;
          let infiles =
            List.map (fun s -> b ^ "_" ^ s ^ ".dk")

--- a/main.ml
+++ b/main.ml
@@ -833,7 +833,7 @@ and command = function
        begin
          let dg = input_value ic in
          Xlp.export_proofs_part b dg k x y;
-         Xlp.export_term_abbrevs b (b^part k);
+         Xlp.export_term_abbrevs_in_one_file b (b^part k);
          Xlp.export_type_abbrevs b (b^part k)
        end;
      close_in ic;
@@ -943,7 +943,7 @@ and command = function
        begin
          Xlp.export_proofs b r;
          if r = All then Xlp.export_theorems b (read_val (b ^ ".thm"));
-         Xlp.export_term_abbrevs b b;
+         Xlp.export_term_abbrevs_in_one_file b b;
          Xlp.export_type_abbrevs b b
        end;
      close_in !Xproof.ic_prf;

--- a/resize-proof
+++ b/resize-proof
@@ -16,6 +16,8 @@ case $1 in
     *) echo "error: not a .lp file"; exit 1;;
 esac
 
+if test -z "$HOL2DK_DIR"; then error '$HOL2DK_DIR is not set'; fi
+
 max=$2
 
 parts=`find . -name "${b}_part_*.lp"`
@@ -54,6 +56,8 @@ do
     echo "generate $g ..."
     if test $k -gt 1; then i=`expr $k - 1`; sed -i -e "\$a require open hol-light.${b}_part_$i;" $h; fi
     cat $h $p > $g
+    echo "generate ${g}o.mk ..."
+    $HOL2DK_DIR/dep-lpo $g > ${g}o.mk
     rm -f $p
 done
 rm -f $h

--- a/resize-term-abbrevs
+++ b/resize-term-abbrevs
@@ -16,6 +16,8 @@ case $1 in
     *) error "not a filename ending with _term_abbrevs.lp";;
 esac
 
+if test -z "$HOL2DK_DIR"; then error '$HOL2DK_DIR is not set'; fi
+
 if test ! -f $1; then error "$1 does not exist"; fi
 max=$2
 
@@ -46,6 +48,8 @@ do
     g=${b}_term_abbrevs$s.lp
     echo "generate $g ..."
     cat $h $p > $g
+    echo "generate ${g}o.mk ..."
+    $HOL2DK_DIR/dep-lpo $g > ${g}o.mk
     rm -f $p
 done
 rm -f $h
@@ -61,4 +65,6 @@ do
         sed -i -e "${l}i require open hol-light.${b}_term_abbrevs_part_$k;" $f
         k=`expr $k + 1`
     done
+    echo "update ${f}o.mk ..."
+    $HOL2DK_DIR/dep-lpo $f > ${f}o.mk
 done

--- a/xdk.ml
+++ b/xdk.ml
@@ -88,10 +88,10 @@ let unabbrev_typ tvs =
   in typ
 ;;
 
-let part : int option ref = ref None;;
+let cur_part : int option ref = ref None;;
 
 let typ_abbrev oc k =
-  match !part with
+  match !cur_part with
   | None -> out oc "type%d" k
   | Some i -> out oc "type%d_%d" i k
 ;;
@@ -238,7 +238,7 @@ let unabbrev_term tvs =
 ;;
 
 let term_abbrev oc k =
-  match !part with
+  match !cur_part with
   | None -> out oc "term%d" k
   | Some i -> out oc "term%d_%d" i k
 ;;
@@ -709,8 +709,8 @@ def or_elim : p : El bool -> q : El bool -> Prf (or p q)
 (* Dedukti file generation with type and term abbreviations. *)
 (****************************************************************************)
 
-let export basename suffix f =
-  let filename = basename ^ suffix ^ ".dk" in
+let export n f =
+  let filename = n ^ ".dk" in
   log "generate %s ...\n%!" filename;
   let oc = open_out filename in
   f oc;
@@ -720,14 +720,14 @@ let export basename suffix f =
 let export_types =
   let f (n,_) = match n with "bool" | "fun" -> false | _ -> true in
   fun b ->
-  export b "_types"
+  export (b^"_types")
     (fun oc ->
       out oc "\n(; type constructors ;)\n";
       list decl_typ oc (List.filter f (types())))
 ;;
 
-let export_type_abbrevs b s =
-  export b (s ^ "_type_abbrevs")
+let export_type_abbrevs b =
+  export (b^"_type_abbrevs")
     (fun oc -> out oc "\n(; type abbreviations ;)\n"; decl_map_typ oc)
 ;;
 
@@ -739,19 +739,19 @@ let export_terms =
     | _ -> true
   in
   fun b ->
-  export b "_terms"
+  export (b^"_terms")
     (fun oc ->
       out oc "\n(; constants ;)\n";
       list decl_sym oc (List.filter f (constants())))
 ;;
 
-let export_term_abbrevs b s =
-  export b (s ^ "_term_abbrevs")
+let export_term_abbrevs b =
+  export (b^"_term_abbrevs")
     (fun oc -> out oc "\n(; term abbreviations ;)\n"; decl_map_term oc)
 ;;
 
 let export_axioms b =
-  export b "_axioms"
+  export (b^"_axioms")
     (fun oc ->
       out oc "\n(; axioms ;)\n";
       decl_axioms oc (axioms());
@@ -760,11 +760,11 @@ let export_axioms b =
 ;;
 
 let export_proofs b r =
-  export b "_proofs"
+  export (b^"_proofs")
     (fun oc -> out oc "\n(; theorems ;)\n"; proofs_in_range oc r);;
 
 let export_theorems b map_thid_name =
-  export b "_theorems"
+  export (b^"_theorems")
     (fun oc ->
       out oc "\n(; named theorems ;)\n";
       MapInt.iter
@@ -773,7 +773,7 @@ let export_theorems b map_thid_name =
 ;;
 
 let export_theorems_as_axioms b map_thid_name =
-  export b "_opam"
+  export (b^"_opam")
     (fun oc ->
       out oc "\n(; named theorems ;)\n";
       MapInt.iter
@@ -782,8 +782,8 @@ let export_theorems_as_axioms b map_thid_name =
 ;;
 
 let export_proofs_part b k x y =
-  part := Some k;
-  export b ("_part_" ^ string_of_int k) (fun oc -> proofs_in_interval oc x y)
+  cur_part := Some k;
+  export (b^part k) (fun oc -> proofs_in_interval oc x y)
 ;;
 
 (****************************************************************************)

--- a/xdk.ml
+++ b/xdk.ml
@@ -372,7 +372,7 @@ let subproof tvs rmap ty_su tm_su ts1 i2 oc p2 =
   in
   match ty_su with
   | [] ->
-     out oc "(thm_%d%a%a%a)" i2 (list_prefix " " typ) tvs2
+     out oc "(lem%d%a%a%a)" i2 (list_prefix " " typ) tvs2
        (list_prefix " " term) vs2 (list_prefix " " (hyp_var ts1)) ts2
   | _ ->
      (* vs2 is now the application of ty_su on vs2 *)
@@ -381,7 +381,7 @@ let subproof tvs rmap ty_su tm_su ts1 i2 oc p2 =
      let ts2 = List.map (inst ty_su) ts2 in
      (* bs is the list of types obtained by applying ty_su on tvs2 *)
      let bs = List.map (type_subst ty_su) tvs2 in
-     out oc "(thm_%d%a%a%a)" i2 (list_prefix " " typ) bs
+     out oc "(lem%d%a%a%a)" i2 (list_prefix " " typ) bs
        (list_prefix " " term) vs2 (list_prefix " " (hyp_var ts1)) ts2
 ;;
 
@@ -599,7 +599,7 @@ let decl_theorem oc k p d =
        List.iteri (fun i t -> out oc "h%d : Prf %a -> " (i+1) term t) ts in
      let hyps oc ts =
        List.iteri (fun i t -> out oc "h%d : Prf %a => " (i+1) term t) ts in
-     out oc "thm thm_%d : %a%a%aPrf %a := %a%a%a%a.\n" k
+     out oc "thm lem%d : %a%a%aPrf %a := %a%a%a%a.\n" k
        (list (decl_typ_param tvs)) tvs
        (list (decl_param tvs rmap)) xs hyps_typ ts term t
        (list (typ_param tvs)) tvs (list (param tvs rmap)) xs hyps ts
@@ -608,14 +608,14 @@ let decl_theorem oc k p d =
      let term = unabbrev_term tvs rmap in
      let hyps_typ oc ts =
        List.iteri (fun i t -> out oc "h%d : Prf %a -> " (i+1) term t) ts in
-     out oc "thm_%d : %a%a%aPrf %a.\n" k
+     out oc "lem%d : %a%a%aPrf %a.\n" k
        (list (decl_typ_param tvs)) tvs
        (list (decl_param tvs rmap)) xs hyps_typ ts term t
   | Named_thm n ->
      let term = unabbrev_term tvs rmap in
      let hyps_typ oc ts =
        List.iteri (fun i t -> out oc "h%d : Prf %a -> " (i+1) term t) ts in
-     out oc "thm thm_%s : %a%a%aPrf %a := thm_%d.\n" n
+     out oc "thm lem%s : %a%a%aPrf %a := lem%d.\n" n
        (list (decl_typ_param tvs)) tvs
        (list (unabbrev_decl_param tvs rmap)) xs hyps_typ ts term t k
 ;;

--- a/xlib.ml
+++ b/xlib.ml
@@ -9,6 +9,8 @@ REMOVE*)
 open Xprelude
 open Fusion
 
+let part i = "_part_" ^ string_of_int i;;
+
 let command s =
   if Sys.command s <> 0 then (log "Error: \"%s\" failed.\n" s; exit 1);;
 

--- a/xlib.ml
+++ b/xlib.ml
@@ -51,7 +51,13 @@ let percent k n = (100 * k) / n;;
 let part i = "_part_" ^ string_of_int i;;
 
 (* Because [List.init n f] fails if [n < 0]. *)
-let init n f = if n <= 0 then [] else List.init n f;;
+let list_init n f = if n <= 0 then [] else List.init n f;;
+
+let list_init_if n f cond =
+  let l = ref [] in
+  for i = 0 to n-1 do if cond i then l := f i :: !l; done;
+  !l
+;;
 
 (* [pos_first f l] returns the position (counting from 0) of the first
    element of [l] satisfying [f]. Raises Not_found if there is no such

--- a/xlib.ml
+++ b/xlib.ml
@@ -9,6 +9,8 @@ REMOVE*)
 open Xprelude
 open Fusion
 
+let open_file n = log "generate %s ...\n%!" n; open_out n;;
+
 let command s =
   if Sys.command s <> 0 then (log "Error: \"%s\" failed.\n" s; exit 1);;
 

--- a/xlib.ml
+++ b/xlib.ml
@@ -50,6 +50,7 @@ let percent k n = (100 * k) / n;;
 
 let part i = "_part_" ^ string_of_int i;;
 
+(* Because [List.init n f] fails if [n < 0]. *)
 let init n f = if n <= 0 then [] else List.init n f;;
 
 (* [pos_first f l] returns the position (counting from 0) of the first

--- a/xlib.ml
+++ b/xlib.ml
@@ -9,8 +9,6 @@ REMOVE*)
 open Xprelude
 open Fusion
 
-let part i = "_part_" ^ string_of_int i;;
-
 let command s =
   if Sys.command s <> 0 then (log "Error: \"%s\" failed.\n" s; exit 1);;
 
@@ -48,7 +46,11 @@ let iter_parts nb_proofs nb_parts f =
 (* Functions on basic data structures. *)
 (****************************************************************************)
 
-let percent k n = (100 * k) / n
+let percent k n = (100 * k) / n;;
+
+let part i = "_part_" ^ string_of_int i;;
+
+let init n f = if n <= 0 then [] else List.init n f;;
 
 (* [pos_first f l] returns the position (counting from 0) of the first
    element of [l] satisfying [f]. Raises Not_found if there is no such

--- a/xlib.ml
+++ b/xlib.ml
@@ -52,15 +52,6 @@ let percent k n = (100 * k) / n;;
 
 let part i = "_part_" ^ string_of_int i;;
 
-(* Because [List.init n f] fails if [n < 0]. *)
-let list_init n f = if n <= 0 then [] else List.init n f;;
-
-let list_init_if n f cond =
-  let l = ref [] in
-  for i = 0 to n-1 do if cond i then l := f i :: !l; done;
-  !l
-;;
-
 (* [pos_first f l] returns the position (counting from 0) of the first
    element of [l] satisfying [f]. Raises Not_found if there is no such
    element. *)

--- a/xlp.ml
+++ b/xlp.ml
@@ -284,21 +284,16 @@ let require oc n = out oc "require open hol-light.%s;\n" n;;
    [n^".lpo"] and [n^".vo"] respectively. *)
 let create (p:string) (iter_deps:(string->unit)->unit) =
   let oc_lp = open_file (p^".lp")
-  and oc_lpo_mk = open_file (p^".lpo.mk")
-  and oc_vo_mk = open_file (p^".vo.mk") in
+  and oc_lpo_mk = open_file (p^".lpo.mk") in
   out oc_lpo_mk "%s.lpo:" p;
-  out oc_vo_mk "%s.vo: coq.vo" p;
   let handle dep =
     require oc_lp dep;
     out oc_lpo_mk " %s.lpo" dep;
-    out oc_vo_mk " %s.vo" dep
   in
   handle "theory_hol";
   iter_deps handle;
   out oc_lpo_mk "\n";
   close_out oc_lpo_mk;
-  out oc_vo_mk "\n";
-  close_out oc_vo_mk;
   oc_lp
 ;;
 
@@ -736,22 +731,17 @@ let export_theorem_deps b n =
   for i = 1 to !cur_part do
     let p = if i < !cur_part then n^part i else n in
     let oc_lp = open_file (p^"_deps.lp")
-    and oc_lpo_mk = open_file (p^".lpo.mk")
-    and oc_vo_mk = open_file (p^".vo.mk") in
+    and oc_lpo_mk = open_file (p^".lpo.mk") in
     out oc_lpo_mk "%s.lpo:" p;
-    out oc_vo_mk "%s.vo: coq.vo" p;
     let f dep =
       require oc_lp dep;
       out oc_lpo_mk " %s.lpo" dep;
-      out oc_vo_mk " %s.vo" dep
     in
     iter_theorem_deps f b n;
     for j = 1 to i-1 do f (n^part j) done;
     close_out oc_lp;
     out oc_lpo_mk "\n";
     close_out oc_lpo_mk;
-    out oc_vo_mk "\n";
-    close_out oc_vo_mk;
     concat (p^"_deps.lp") (p^"_proofs.lp") (p^".lp");
   done
 ;;

--- a/xlp.ml
+++ b/xlp.ml
@@ -304,7 +304,7 @@ let require oc n = out oc "require open hol-light.%s;\n" n;;
 
 let term_abbrevs_deps n =
   (n^"_term_abbrevs")
-  :: List.init (!abbrev_part - 1) (fun k -> n^"_term_abbrevs"^part(k+2))
+  :: Xlib.init (!abbrev_part - 1) (fun k -> n^"_term_abbrevs"^part(k+2))
 ;;
 
 let require_term_abbrevs oc n = List.iter (require oc) (term_abbrevs_deps n);;
@@ -651,7 +651,7 @@ let theorem_deps b n k =
   [b^"_types"; n^"_type_abbrevs"; b^"_terms"; b^"_axioms"]
   @ (if !use_sharing then [n^"_subterm_abbrevs"] else [])
   @ term_abbrevs_deps n
-  @ List.init k (fun i -> n^part(i+1))
+  @ Xlib.init k (fun i -> n^part(i+1))
   @ SetStr.elements !thdeps
 ;;
 

--- a/xlp.ml
+++ b/xlp.ml
@@ -647,16 +647,6 @@ let export_deps n suffix l =
   close_out oc
 ;;
 
-let theorem_deps b n k =
-  [b^"_types"; n^"_type_abbrevs"; b^"_terms"; b^"_axioms"]
-  @ (if !use_sharing then [n^"_subterm_abbrevs"] else [])
-  @ term_abbrevs_deps n
-  @ Xlib.init k (fun i -> n^part(i+1))
-  @ SetStr.elements !thdeps
-;;
-
-let theorem_deps oc b n k = List.iter (require oc) (theorem_deps b n k);;
-
 (* [export n f] creates a file named [n^".lp"] and calls [f] with the
    corresponding out_channel. *)
 let export n f =
@@ -726,6 +716,16 @@ let export_theorem_proof n =
     (!the_start_idx + Array.length !prf_pos - 1)
 ;;
 
+let theorem_deps b n k =
+  [b^"_types"; b^"_terms"; b^"_axioms"; n^"_type_abbrevs"]
+  @ (if !use_sharing then [n^"_subterm_abbrevs"] else [])
+  @ term_abbrevs_deps n
+  @ Xlib.init k (fun i -> n^part(i+1))
+  @ SetStr.elements !thdeps
+;;
+
+let theorem_deps oc b n k = List.iter (require oc) (theorem_deps b n k);;
+
 let export_theorem_deps b n =
   for i = 1 to !cur_part do
     let f = n ^ part i in
@@ -772,7 +772,7 @@ let export_term_abbrevs b n =
     export_with_deps (n^"_subterm_abbrevs") deps decl_subterm_abbrevs
 ;;
 
-let new_export_term_abbrevs b n =
+let export_theorem_term_abbrevs b n =
   new_decl_term_abbrevs b n;
   if !use_sharing then
     export_with_deps (n^"_subterm_abbrevs")
@@ -785,8 +785,8 @@ let export_axioms b =
     (fun oc -> decl_axioms oc (axioms()))
 ;;
 
-let export_proofs b n r =
-  export (n^"_proofs") (fun oc -> theorem_deps oc b n 0; proofs_in_range oc r)
+let export_proofs b r =
+  export (b^"_proofs") (fun oc -> theorem_deps oc b b 0; proofs_in_range oc r)
 ;;
 
 let out_map_thid_name as_axiom oc map_thid_name =


### PR DESCRIPTION
- generate lpo and vo dependencies for make when generating lp files
- xlp.ml and xdk.ml: remove suffix argument from export functions
- use iterators for dependencies
- improve and simplify Makefile: lpo and vo dependencies are automatically computed
- changed prefix of lemmas to "lem" instead of "thm_" before

performance:

hol.ml:
  - without generation: make -j32 lp 47s dep-lpo 42s
  - with generation: make -j32 lp 46s dep-lpo 0.4s

TODO:
- [x] fix .lpo.mk files when calling resize scripts