### PR TITLE
optimize dependencies of proof files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           cp xci.ml hol-light/
           cd hol-light
           hol2dk dump-simp-use xci.ml
-      - name: Generate and check single-threaded dk output
+      - name: Test single-threaded dk output
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
@@ -61,7 +61,7 @@ jobs:
           ln -s ../theory_hol.dk
           hol2dk xci.dk
           dk check xci.dk
-      - name: Generate and check single-threaded lp output
+      - name: Test single-threaded lp output
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
@@ -70,7 +70,7 @@ jobs:
           ln -s ../theory_hol.lp
           ln -s ../lambdapi.pkg
           lambdapi check xci.lp
-      - name: Generate and check multi-threaded dk output with mk
+      - name: Test multi-threaded dk output with mk
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
@@ -78,14 +78,14 @@ jobs:
           hol2dk mk 3 xci
           make -f xci.mk -j3 dk
           dk check xci.dk
-      - name: Generate and check multi-threaded lp output with mk
+      - name: Test multi-threaded lp output with mk
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
           cd hol-light
           make -f xci.mk -j3 lp
           make -f xci.mk -j3 lpo
-      - name: Generate and check multi-threaded lp output with split
+      - name: Test multi-threaded lp output with split
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
@@ -97,22 +97,48 @@ jobs:
           make -j3 lp
           make -j3 v
           make -j3 lpo
-      - name: Check resizing
+      - name: Test --max-steps 250 and --max-abbrevs 200
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
           export HOLLIGHT_DIR=`pwd`/hol-light
-          mkdir -p output/xci
           cd output/xci
-          hol2dk link xci
-          make split
+          make clean-lp
           make -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
           make -j3 lpo
+      - name: Check resize thm75360.lp 500
+        run: |
+          eval `opam env`
+          export HOL2DK_DIR=`pwd`
+          export HOLLIGHT_DIR=`pwd`/hol-light
+          cd output/xci
+          make clean-lpo
           hol2dk resize thm75360.lp 500
           make -j3 lpo
+      - name: Check resize thm75360.lp 100
+        run: |
+          eval `opam env`
+          export HOL2DK_DIR=`pwd`
+          export HOLLIGHT_DIR=`pwd`/hol-light
+          cd output/xci
+          make clean-lpo
           hol2dk resize thm75360.lp 100
           make -j3 lpo
+      - name: Check resize thm75360_term_abbrevs.lp 300
+        run: |
+          eval `opam env`
+          export HOL2DK_DIR=`pwd`
+          export HOLLIGHT_DIR=`pwd`/hol-light
+          cd output/xci
+          make clean-lpo
           hol2dk resize thm75360_term_abbrevs.lp 300
           make -j3 lpo
+      - name: Check resize thm75360_term_abbrevs.lp 100
+        run: |
+          eval `opam env`
+          export HOL2DK_DIR=`pwd`
+          export HOLLIGHT_DIR=`pwd`/hol-light
+          cd output/xci
+          make clean-lpo
           hol2dk resize thm75360_term_abbrevs.lp 100
           make -j3 lpo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,15 +76,15 @@ jobs:
           export HOL2DK_DIR=`pwd`
           cd hol-light
           hol2dk mk 3 xci
-          gmake -f xci.mk -j3 dk
+          make -f xci.mk -j3 dk
           dk check xci.dk
       - name: Generate and check multi-threaded lp output with mk
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
           cd hol-light
-          gmake -f xci.mk -j3 lp
-          gmake -f xci.mk -j3 lpo
+          make -f xci.mk -j3 lp
+          make -f xci.mk -j3 lpo
       - name: Generate and check multi-threaded lp output with split
         run: |
           eval `opam env`
@@ -93,10 +93,10 @@ jobs:
           mkdir -p output/xci
           cd output/xci
           hol2dk link xci
-          gmake split
-          gmake -j3 lp
-          gmake -j3 v
-          gmake -j3 lpo
+          make split
+          make -j3 lp
+          make -j3 v
+          make -j3 lpo
       - name: Check resizing
         run: |
           eval `opam env`
@@ -105,14 +105,14 @@ jobs:
           mkdir -p output/xci
           cd output/xci
           hol2dk link xci
-          gmake split
-          gmake -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
-          gmake -j3 lpo
+          make split
+          make -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
+          make -j3 lpo
           hol2dk resize thm75360.lp 500
-          gmake -j3 lpo
+          make -j3 lpo
           hol2dk resize thm75360.lp 100
-          gmake -j3 lpo
+          make -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 300
-          gmake -j3 lpo
+          make -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 100
-          gmake -j3 lpo
+          make -j3 lpo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,15 +76,15 @@ jobs:
           export HOL2DK_DIR=`pwd`
           cd hol-light
           hol2dk mk 3 xci
-          make -f xci.mk -j3 dk
+          gmake -f xci.mk -j3 dk
           dk check xci.dk
       - name: Generate and check multi-threaded lp output with mk
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
           cd hol-light
-          make -f xci.mk -j3 lp
-          make -f xci.mk -j3 lpo
+          gmake -f xci.mk -j3 lp
+          gmake -f xci.mk -j3 lpo
       - name: Generate and check multi-threaded lp output with split
         run: |
           eval `opam env`
@@ -93,10 +93,10 @@ jobs:
           mkdir -p output/xci
           cd output/xci
           hol2dk link xci
-          make split
-          make -j3 lp
-          make -j3 v
-          make -j3 lpo
+          gmake split
+          gmake -j3 lp
+          gmake -j3 v
+          gmake -j3 lpo
       - name: Check resizing
         run: |
           eval `opam env`
@@ -105,14 +105,14 @@ jobs:
           mkdir -p output/xci
           cd output/xci
           hol2dk link xci
-          make split
-          make -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
-          make -j3 lpo
+          gmake split
+          gmake -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
+          gmake -j3 lpo
           hol2dk resize thm75360.lp 500
-          make -j3 lpo
+          gmake -j3 lpo
           hol2dk resize thm75360.lp 100
-          make -j3 lpo
+          gmake -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 300
-          make -j3 lpo
+          gmake -j3 lpo
           hol2dk resize thm75360_term_abbrevs.lp 100
-          make -j3 lpo
+          gmake -j3 lpo

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,14 @@ $(BASE_FILES:%=%.lp) &:
 .PHONY: lp
 lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp)
 
-HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 10000
+HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 20000
 
 %.lp %.lpo.mk &: %.sti
 	hol2dk $(HOL2DK_OPTIONS) theorem $(BASE) $*.lp
 
 FILES_WITH_SHARING = $(shell if test -f FILES_WITH_SHARING; then cat FILES_WITH_SHARING; fi)
 
-#$(FILES_WITH_SHARING:%=%.lp): HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 100000 #--use-sharing
+#$(FILES_WITH_SHARING:%=%.lp): HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 20000 #--use-sharing
 
 .PHONY: clean-lp
 clean-lp: clean-mk clean-lpo clean-v clean-vo

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp)
 HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 10000
 
 %.lp %.lpo.mk &: %.sti
-	hol2dk $(HOL2DK_OPTIONS) theorem $(BASE) $@
+	hol2dk $(HOL2DK_OPTIONS) theorem $(BASE) $*.lp
 
 FILES_WITH_SHARING = $(shell if test -f FILES_WITH_SHARING; then cat FILES_WITH_SHARING; fi)
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,13 @@ FILES_WITH_SHARING = $(shell if test -f FILES_WITH_SHARING; then cat FILES_WITH_
 #$(FILES_WITH_SHARING:%=%.lp): HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 100000 #--use-sharing
 
 .PHONY: clean-lp
-clean-lp: clean-lpo clean-v clean-vo
+clean-lp: clean-mk clean-lpo clean-v clean-vo
 	find . -maxdepth 1 -name '*.lp' -a ! -name theory_hol.lp -delete
+
+.PHONY: clean-mk
+clean-mk:
+	find . -maxdepth 1 -name '*.lpo.mk' -delete
+	rm -f lpo.mk vo.mk
 
 include lpo.mk
 
@@ -88,11 +93,20 @@ COQC_OPTIONS = # -w -coercions
 	@coqc $(COQC_OPTIONS) -R . HOLLight $<
 
 .PHONY: clean-vo
-clean-vo:
-	find . -maxdepth 1 -name '*.vo*' -delete
-	find . -maxdepth 1 -name '*.glob' -delete
-	find . -maxdepth 1 -name '.*.aux' -delete
+clean-vo: clean-vos clean-glob clean-aux
 	rm -f .lia.cache .nia.cache
+
+.PHONY: clean-vos
+clean-vos:
+	find . -maxdepth 1 -name '*.vo*' -delete
+
+.PHONY: clean-glob
+clean-glob:
+	find . -maxdepth 1 -name '*.glob' -delete
+
+.PHONY: clean-aux
+clean-aux:
+	find . -maxdepth 1 -name '.*.aux' -delete
 
 .PHONY: opam
 opam: $(BASE)_opam.vo
@@ -107,12 +121,7 @@ clean-opam:
 	rm -f $(BASE)_opam.*
 
 .PHONY: clean-all
-clean-all: clean-split clean-lp clean-lpo clean-v clean-vo clean-opam clean-mk
-
-.PHONY: clean-mk
-clean-mk:
-	find . -maxdepth 1 -name '*.lpo.mk' -delete
-	rm -f lpo.mk vo.mk
+clean-all: clean-split clean-lp clean-lpo clean-v clean-vo clean-opam
 
 .PHONY: all
 all:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp)
 
 HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 10000
 
-%.lp: %.sti
+%.lp %.lpo.mk &: %.sti
 	hol2dk $(HOL2DK_OPTIONS) theorem $(BASE) $@
 
 FILES_WITH_SHARING = $(shell if test -f FILES_WITH_SHARING; then cat FILES_WITH_SHARING; fi)
@@ -46,11 +46,10 @@ include lpo.mk
 LP_FILES := $(wildcard *.lp)
 
 lpo.mk: $(LP_FILES:%.lp=%.lpo.mk)
-	echo > lpo.mk
-	find . -maxdepth 1 -name '*.lpo.mk' -exec cat {} > lpo.mk \;
+	find . -maxdepth 1 -name '*.lpo.mk' | xargs cat > $@
 #	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lpo {} \; > lpo.mk
 
-%.lpo.mk: %.lp
+theory_hol.lpo.mk: theory_hol.lp
 	$(HOL2DK_DIR)/dep-lpo $< > $@
 
 .PHONY: lpo

--- a/NOTES.md
+++ b/NOTES.md
@@ -5,7 +5,7 @@ NOTES
 
 splitting term abbrevs by size instead of by number:
 
-hol.lp --max-abbrevs 20000: make -j32 lp 41s v 47s vo -j16 37m3s
+hol.lp --max-abbrevs 20000: make -j32 lp 41s v 47s -j16 vo 37m3s
 
 ## 11/03/24
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -5,7 +5,7 @@ NOTES
 
 splitting term abbrevs by size instead of by number:
 
-hol.lp --max-abbrevs 10000: make -j32 lp 41s v 47s vo -j16 39m50s
+hol.lp --max-abbrevs 20000: make -j32 lp 41s v 47s vo -j16 37m3s
 
 ## 11/03/24
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,17 +1,24 @@
 NOTES
 -----
 
-## 13/03/24
+## 15/03/24
 
 optimizing dependencies:
 
-hol.lp --max-abbrevs 20000: make -j32 lp 42s v 41s -j16 vo 32m40s
+hol.ml --max-abbrevs 20000: make -j32 lp 45s v 41s -j16 vo 37m28s
+hol.ml --max-abbrevs 10000: make -j32 lp 47s v 47s -j16 vo 42m30s
+
+## 13/03/24
+
+optimizing dependencies on term_abbrevs:
+
+hol.ml --max-abbrevs 20000: make -j32 lp 42s v 41s -j16 vo 32m40s
 
 ## 12/03/24
 
 splitting term abbrevs by size instead of by number:
 
-hol.lp --max-abbrevs 20000: make -j32 lp 41s v 47s -j16 vo 37m3s
+hol.ml --max-abbrevs 20000: make -j32 lp 41s v 47s -j16 vo 37m3s
 
 ## 11/03/24
 
@@ -187,9 +194,9 @@ a solution is to use (maximal) sharing when building the map of term abbreviatio
 
 but sharing increases generation time significantly
 
-with split and -j32, hol.lp is generated in 40s instead of 32s (+25%)
+with split and -j32, hol.ml is translated to lp in 40s instead of 32s (+25%)
 
-in singly-threaded mode, hol.lp is generated in 4m59s instead of 4m7s (+21%)
+in singly-threaded mode, hol.ml is translated to lp in 4m59s instead of 4m7s (+21%)
 
 however GRASSMANN_PLUCKER_4.lp can now be generated in 2 hours (119m23s)
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,12 @@
 NOTES
 -----
 
+## 13/03/24
+
+optimizing dependencies:
+
+hol.lp --max-abbrevs 20000: make -j32 lp 42s v 41s -j16 vo 32m40s
+
 ## 12/03/24
 
 splitting term abbrevs by size instead of by number:

--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,6 @@ TODO
 
 - generate term_abbrevs parts in parallel by dumping the htable and then reading the dumped list in parallel
 
-- optimize dependencies of a proof part wrt term abbrevs by defining term abbrevs in order and recording the term abbrevs used by each proof part
-
 - optimize number of let's (use a let only if an abbreviation is used more than once)
 
 - remove base argument in all commands by using BASE file

--- a/main.ml
+++ b/main.ml
@@ -356,13 +356,15 @@ let basename_ml f =
 
 let print_hstats() =
   log "\nstring: %a\ntype: %a\nterm: %a\ntype_abbrev: %a\nterm_abbrev: %a\
-       \nsubterms: %a"
+       \nsubterms: %a\nabbrev_part: %a\npart_abbrev_max: %a"
     hstats (StrHashtbl.stats htbl_string)
     hstats (TypHashtbl.stats htbl_type)
     hstats (TrmHashtbl.stats htbl_term)
     hstats (TypHashtbl.stats htbl_type_abbrev)
     hstats (TrmHashtbl.stats htbl_term_abbrev)
     hstats (TrmHashtbl.stats htbl_subterms)
+    hstats (Hashtbl.stats Xlp.htbl_abbrev_part)
+    hstats (Hashtbl.stats Xlp.htbl_part_abbrev_max)
 
 let valid_coq_filename s = match s with "at" -> "_" ^ s | _ -> s;;
 
@@ -400,7 +402,8 @@ and command = function
 
   | "--use-sharing"::args -> use_sharing := true; command args
 
-  | "--max-abbrevs"::k::args -> Xlp.max_abbrevs := integer k; command args
+  | "--max-abbrevs"::k::args ->
+     Xlp.max_abbrev_part_size := integer k; command args
 
   | "--max-steps"::k::args -> Xlp.max_steps := integer k; command args
 

--- a/main.ml
+++ b/main.ml
@@ -527,7 +527,7 @@ and command = function
      and nb_terms_gtl = ref 0 in
      let handle_term t =
        incr nb_terms;
-       let s = size t in
+       let s = nb_cons t in
        if s > !max_size then max_size := s;
        if s > l then incr nb_terms_gtl;
        sum_size := s + !sum_size

--- a/main.ml
+++ b/main.ml
@@ -364,7 +364,7 @@ let print_hstats() =
     hstats (TrmHashtbl.stats htbl_term_abbrev)
     hstats (TrmHashtbl.stats htbl_subterms)
     hstats (Hashtbl.stats Xlp.htbl_abbrev_part)
-    hstats (Hashtbl.stats Xlp.htbl_part_abbrev_max)
+    hstats (Hashtbl.stats Xlp.htbl_abbrev_part_max)
 
 let valid_coq_filename s = match s with "at" -> "_" ^ s | _ -> s;;
 

--- a/resize-proof
+++ b/resize-proof
@@ -29,7 +29,7 @@ n=`expr $n - 1`
 if test ! -f $1; then echo "error: $1 does not exist"; exit 1; fi
 h=${b}_header.lp
 echo "generate $h ..."
-awk '/^require /{print;next}{nextfile}' $1 > $h
+awk '/^require /{print;next}{nextfile}' $1 ${b}_part_*.lp | sort -u > $h
 sed -i -e "/^require open hol-light.${b}_part_/d" $h
 
 p=${b}_proofs.lp

--- a/resize-proof
+++ b/resize-proof
@@ -62,5 +62,5 @@ do
 done
 rm -f $h
 
-echo "warning: all theorems are exported"
+echo "warning: all theorems are exported and dependencies are not optimal"
 echo "do \"make $1\" to optimize this"

--- a/resize-term-abbrevs
+++ b/resize-term-abbrevs
@@ -44,8 +44,7 @@ n=`ls x[0-9]* | wc -l`
 for p in `ls x[0-9]*`
 do
     k=`expr ${p#x} + 0` # remove leading zeros
-    if test $k -eq 1; then s=''; else s=_part_$k; fi
-    g=${b}_term_abbrevs$s.lp
+    g=${b}_term_abbrevs_part_$k.lp
     echo "generate $g ..."
     cat $h $p > $g
     echo "generate ${g}o.mk ..."

--- a/resize-term-abbrevs
+++ b/resize-term-abbrevs
@@ -18,16 +18,17 @@ esac
 
 if test -z "$HOL2DK_DIR"; then error '$HOL2DK_DIR is not set'; fi
 
-if test ! -f $1; then error "$1 does not exist"; fi
+f=${b}_term_abbrevs_part_1.lp
+if test ! -f $f; then error "$f does not exist"; fi
 max=$2
 
 h=${b}_term_abbrevs_header.lp
 echo "generate $h ..."
-awk '/^symbol /{nextfile}{print}' $1 > $h
+awk '/^symbol /{nextfile}{print}' $f > $h
 
 a=${b}_term_abbrevs_without_header.lp
 echo "generate $a ..."
-cat $1 `find . -name "${b}_term_abbrevs_part_*.lp"` > $a
+cat `find . -name "${b}_term_abbrevs_part_*.lp"` > $a
 sed -i -e '/^require /d' $a
 
 ls x[0-9]* 2> /dev/null
@@ -37,7 +38,7 @@ split --numeric-suffixes=1 -a5 -l$max $a
 
 echo "generate $1.bak ..."
 cat $h $a > $1.bak
-rm -f $a $1 ${b}_term_abbrevs_part_*.lp
+rm -f $a ${b}_term_abbrevs_part_*.lp
 
 n=`ls x[0-9]* | wc -l`
 
@@ -57,7 +58,7 @@ for f in $b.lp `find . -name "${b}_part_*.lp"`
 do
     echo "update $f ..."
     sed -i -e "/^require open hol-light.${b}_term_abbrevs_part_/d" $f
-    k=2
+    k=1
     while test $k -le $n
     do
         l=`expr $k + 5`
@@ -67,3 +68,6 @@ do
     echo "update ${f}o.mk ..."
     $HOL2DK_DIR/dep-lpo $f > ${f}o.mk
 done
+
+echo "warning: dependencies are not optimal"
+echo "do \"make $1\" to optimize this"

--- a/xdk.ml
+++ b/xdk.ml
@@ -248,7 +248,7 @@ let abbrev_term =
   let abbrev oc t =
     (* check whether the term is already abbreviated; add a new
        abbreviation if needed *)
-    let tvs, vs, bs, t = canonical_term t in
+    let tvs, vs, bs, t, _ = canonical_term t in
     let k =
       match TrmHashtbl.find_opt htbl_term_abbrev t with
       | Some (k,_,_) -> k

--- a/xlib.ml
+++ b/xlib.ml
@@ -603,22 +603,24 @@ let canonical_term =
    canonical type variables [a0, a1, ...], [vs] are replaced by
    canonical term variables [x0, x1, ...], and the abstracted term
    variables are replaced by canonical variables [y0, y1, ...]. Hence,
-   if [t'] is alpha-equivalent to [t], then [canonical_term t' = u]. *)
+   if [t'] is alpha-equivalent to [t], then [canonical_term t' = u],
+- [n] is the size of [t]. *)
 let canonical_term
-    : term -> hol_type list * term list * hol_type list * term =
+    : term -> hol_type list * term list * hol_type list * term * int =
   (*let a_max = ref 0 and x_max = ref 0 and y_max = ref 0 in*)
   let sy = Array.init 50 (fun i -> "y" ^ string_of_int i) in
   (* [subst i su t] applies [su] on [t] and rename abstracted
      variables as well by incrementing the integer [i]. [su] is a term
      substitution mapping term variables abstracted in [t] by the
      canonical term variables [y0, y1, ...]. *)
+  let size = ref 0 in
   let rec subst i su t =
     (*log "subst %d %a %a\n%!" i (olist (opair oterm oterm)) su oterm t;*)
     match t with
     | Var _ -> (try List.assoc t su with Not_found -> assert false)
     | Const(s,b) -> hmk_const(s,b)
-    | Comb(u,v) -> hmk_comb(subst i su u, subst i su v)
-    | Abs(u,v) ->
+    | Comb(u,v) -> incr size; hmk_comb(subst i su u, subst i su v)
+    | Abs(u,v) -> incr size;
        match u with
        | Var(_,b) ->
           let s =
@@ -630,6 +632,7 @@ let canonical_term
        | _ -> assert false
   in
   fun t ->
+  size := 0;
   let tvs = type_vars_in_term t and vs = frees t in
   (* Type substitution mapping type variables of [t] to the canonical
      type variables [a0, a1, ...]. *)
@@ -639,7 +642,7 @@ let canonical_term
   (* Term substitution mapping term variables of [t] to the canonical
      term variables [x0, x1, ...]. *)
   and su' = List.mapi term_var vs' in
-  tvs, vs, bs, subst 0 su' t'
+  tvs, vs, bs, subst 0 su' t', !size
 ;;
 
 (****************************************************************************)

--- a/xlib.ml
+++ b/xlib.ml
@@ -132,6 +132,9 @@ let rec change_prefixes l s =
      if starts_with p s then q ^ String.sub s n (String.length s - n)
      else change_prefixes l s
 
+(* [bindings ht] returns the list of bindings in the hash table [ht]. *)
+let bindings ht = Hashtbl.fold (fun x y acc -> (x,y)::acc) ht [];;
+
 (****************************************************************************)
 (* Printing functions. *)
 (****************************************************************************)
@@ -142,9 +145,9 @@ let string oc s = out oc "%s" s;;
 
 let ostring oc s = out oc "\"%s\"" s;;
 
-let pair f g oc (x, y) = out oc "%a, %a" f x g y;;
+let pair f g oc (x, y) = out oc "%a,%a" f x g y;;
 
-let opair f g oc (x, y) = out oc "(%a, %a)" f x g y;;
+let opair f g oc (x, y) = out oc "(%a,%a)" f x g y;;
 
 let prefix p elt oc x = out oc "%s%a" p elt x;;
 
@@ -159,6 +162,10 @@ let list elt oc xs = list_sep "" elt oc xs;;
 let olist elt oc xs = out oc "[%a]" (list_sep "; " elt) xs;;
 
 let list_prefix p elt oc xs = list (prefix p elt) oc xs;;
+
+let htbl ppkey ppval oc ht =
+  (*Hashtbl.iter (opair oc)*)
+  List.iter (opair ppkey ppval oc) (List.sort Stdlib.compare (bindings ht));;
 
 let hstats oc hs =
   let open Hashtbl in

--- a/xlib.ml
+++ b/xlib.ml
@@ -427,17 +427,6 @@ let head_args =
   in aux []
 ;;
 
-(* [head_args_size t] returns the tuple [h,ts,n] such that [t] is the
-   application of [h] to [ts] and [h] is not a [Comb], and [n] is the
-   length of [ts]. *)
-let head_args_size =
-  let rec aux (acc,n) t =
-    match t with
-    | Comb(t1,t2) -> aux (t2::acc,n+1) t1
-    | _ -> t, acc, n
-  in aux ([],0)
-;;
-
 (* [binop_args t] returns the terms [u,v] assuming that [t] is of the
    form [Comb(Comb(_,u),v)]. *)
 let binop_args t =

--- a/xlp.ml
+++ b/xlp.ml
@@ -698,7 +698,6 @@ let export_theorem_term_abbrevs b n =
     cur_oc := create f iter_deps
   in
   let handle_abbrev t x =
-    incr abbrev_idx;
     if !abbrev_part_size >= !max_abbrevs then
       begin
         close_out !cur_oc;
@@ -706,6 +705,7 @@ let export_theorem_term_abbrevs b n =
         Hashtbl.add htbl_abbrev_part !abbrev_part !abbrev_idx;
         create_new_part();
       end;
+    incr abbrev_idx;
     abbrev !cur_oc t x
   in
   create_new_part();

--- a/xlp.ml
+++ b/xlp.ml
@@ -255,7 +255,6 @@ let abbrev_term =
     let k =
       match TrmHashtbl.find_opt htbl_term_abbrev t with
       | Some (k,_,_) ->
-         log "add proof_abdeps %d\n%!" (part_of k);
          proof_abdeps := SetInt.add (part_of k) !proof_abdeps;
          k
       | None ->
@@ -263,18 +262,14 @@ let abbrev_term =
          let ltvs = List.length tvs and lvs = List.length vs in
          abbrev_part_size := !abbrev_part_size + n + 1 + ltvs + lvs;
          if !abbrev_part_size > !max_abbrev_part_size then
-           (log "add htbl_abbrev_part_max %d %d\n%!" !abbrev_part !cur_abbrev;
-            Hashtbl.add htbl_abbrev_part_max !abbrev_part !cur_abbrev;
-            log "incr abbrev_part\n%!";
+           (Hashtbl.add htbl_abbrev_part_max !abbrev_part !cur_abbrev;
             incr abbrev_part;
-            log "add htbl_abbrev_part_min %d %d\n%!" !abbrev_part k;
             Hashtbl.add htbl_abbrev_part_min !abbrev_part k);
          (*if k mod 1000 = 0 then log "term abbrev %d\n%!" k;*)
          (*out oc_abbrevs "%a\n\n" raw_term t;*)
          cur_abbrev := k;
          let x = (k, ltvs, bs) in
          TrmHashtbl.add htbl_term_abbrev t x;
-         log "add htbl_abbrev_part %d %d\n%!" k !abbrev_part;
          Hashtbl.add htbl_abbrev_part k !abbrev_part;
          proof_abdeps := SetInt.add !abbrev_part !proof_abdeps;
          k
@@ -679,7 +674,6 @@ let export_theorem_term_abbrevs b n =
   let l = TrmHashtbl.fold (fun t x acc -> (t,x)::acc) htbl_term_abbrev [] in
   let cmp (_,(k1,_,_)) (_,(k2,_,_)) = Stdlib.compare k1 k2 in
   let l = ref (List.sort cmp l) in
-  log "htbl_term_abbrev: %a\n%!" (olist (fun oc (_,(k,_,_)) -> int oc k)) !l;
   let iter_deps f =
     f (b^"_types");
     f (n^"_type_abbrevs");
@@ -689,7 +683,6 @@ let export_theorem_term_abbrevs b n =
   let part_abbrev (i,min) =
     let abbrevs oc =
       let max = Hashtbl.find htbl_abbrev_part_max i in
-      log "abbrevs %d .. %d\n%!" min max;
       for _ = min to max do
         match !l with
         | [] -> assert false
@@ -738,7 +731,6 @@ let export_proofs_in_interval n x y =
     done;
     proof_part_max_idx := !i - 2
   in
-  log "add htbl_abbrev_part_min 1 0\n%!";
   Hashtbl.add htbl_abbrev_part_min 1 0;
   proof_part := 0;
   start_part x;
@@ -749,8 +741,6 @@ let export_proofs_in_interval n x y =
         if !nb_steps > !max_steps then
           begin
             close_out !cur_oc;
-            log "%d: %a\n%!" !proof_part
-              (olist int) (SetInt.elements !proof_abdeps);
             Hashtbl.add htbl_proof_abdeps !proof_part !proof_abdeps;
             start_part k
           end;
@@ -760,7 +750,6 @@ let export_proofs_in_interval n x y =
   done;
   close_out !cur_oc;
   Hashtbl.add htbl_abbrev_part_max !abbrev_part !cur_abbrev;
-  log "%d: %a\n%!" !proof_part (olist int) (SetInt.elements !proof_abdeps);
   Hashtbl.add htbl_proof_abdeps !proof_part !proof_abdeps
 ;;
 

--- a/xlp.ml
+++ b/xlp.ml
@@ -661,15 +661,12 @@ let abbrev_part_of i =
 ;;
 
 (* [abbrev_parts_of i j] returns the abbrev part numbers containing
-   the abbreviation numbers [i] and [j] respectively. *)
-let _abbrev_parts_of i j =
+   the abbreviation numbers [i] and [j] respectively. We implement an
+   optimization of [let abbrev_parts_of i j = abbrev_part_of i,
+   abbrev_part_of j] doing only one traversal of
+   [htbl_abbrev_part]. *)
+let abbrev_parts_of i j =
   let pi = ref !abbrev_part and pj = ref !abbrev_part in
-  (*let f part index_max =
-    if index_max >= i then pi := min !pi part;
-    if index_max >= j then pj := min !pj part
-  in
-  Hashtbl.iter f htbl_abbrev_part;*)
-  (* optimization: *)
   let f_j_ge_i part index_max =
     if index_max >= j then (pj := min !pj part; pi := min !pi part)
     else if index_max >= i then pi := min !pi part
@@ -682,8 +679,6 @@ let _abbrev_parts_of i j =
   Hashtbl.iter f htbl_abbrev_part;
   !pi, !pj
 ;;
-
-let abbrev_parts_of i j = abbrev_part_of i, abbrev_part_of j;;
 
 (* [export_theorem_term_abbrevs b n] writes the term abbreviations in
    the files [n^"_term_abbrevs"^part(k)^".lp"]. *)

--- a/xlp.ml
+++ b/xlp.ml
@@ -850,7 +850,13 @@ let out_map_thid_name as_axiom oc map_thid_name =
     map_thid_name
 ;;
 
-let iter_theorems_deps b f = iter_proofs_deps b f; f (b^"_proofs");;
+let iter_theorems_deps b f =
+  f (b^"_types");
+  f (b^"_type_abbrevs");
+  f (b^"_terms");
+  f (b^"_axioms");
+  f (b^"_proofs")
+;;
 
 let export_theorems b map_thid_name =
   export_iter b (iter_theorems_deps b)

--- a/xlp.ml
+++ b/xlp.ml
@@ -227,6 +227,9 @@ let unabbrev_term =
   in term
 ;;
 
+(* Index of the current term_abbrevs_part file. *)
+let abbrev_part = ref 0;;
+
 let abbrev_term =
   (*let oc_abbrevs = open_out "term_abbrevs" in*)
   let idx = ref (-1) in
@@ -643,22 +646,19 @@ let export_term_abbrevs_in_one_file b n =
 (* Maximum size of a term_abbrev file. *)
 let max_abbrevs = ref max_int;;
 
-(* Number of term_abbrevs_part files. *)
-let abbrev_part = ref 0;;
-
 (* Map every abbrev part to its maximal abbrev index. *)
 let htbl_abbrev_part = Hashtbl.create 1000;;
 
 (* [abbrev_part_of i] returns the abbrev part number containing the
    abbreviation number [i]. *)
-let abbrev_part_of i =
+(*let abbrev_part_of i =
   let htbl oc = Hashtbl.iter (out oc "(%d,%d)") in
   let res = ref !abbrev_part in
   let f part index_max = if index_max >= i then res := min !res part in
   Hashtbl.iter f htbl_abbrev_part;
   log "abbrev_part_of %d in %a = %d\n%!" i htbl htbl_abbrev_part !res;
   !res
-;;
+;;*)
 
 (* [abbrev_parts_of i j] returns the abbrev part numbers containing
    the abbreviation numbers [i] and [j] respectively. We implement an
@@ -677,6 +677,9 @@ let abbrev_parts_of i j =
   in
   let f = if j >= i then f_j_ge_i else f_i_ge_j in
   Hashtbl.iter f htbl_abbrev_part;
+  let htbl = htbl int int in
+  log "abbrev_part_of %d in %a = %d\n%!" i htbl htbl_abbrev_part !pi;
+  log "abbrev_part_of %d in %a = %d\n%!" j htbl htbl_abbrev_part !pj;
   !pi, !pj
 ;;
 

--- a/xlp.ml
+++ b/xlp.ml
@@ -262,9 +262,12 @@ let abbrev_term =
          let ltvs = List.length tvs and lvs = List.length vs in
          abbrev_part_size := !abbrev_part_size + n + 1 + ltvs + lvs;
          if !abbrev_part_size > !max_abbrev_part_size then
-           (Hashtbl.add htbl_abbrev_part_max !abbrev_part !cur_abbrev;
-            incr abbrev_part;
-            Hashtbl.add htbl_abbrev_part_min !abbrev_part k);
+           begin
+             Hashtbl.add htbl_abbrev_part_max !abbrev_part !cur_abbrev;
+             incr abbrev_part;
+             Hashtbl.add htbl_abbrev_part_min !abbrev_part k;
+             abbrev_part_size := 0
+           end;
          (*if k mod 1000 = 0 then log "term abbrev %d\n%!" k;*)
          (*out oc_abbrevs "%a\n\n" raw_term t;*)
          cur_abbrev := k;

--- a/xlp.ml
+++ b/xlp.ml
@@ -661,7 +661,7 @@ print lem%d;\n" x*)
 
 let export_term_abbrevs_in_one_file b n =
   let deps = [b^"_types"; n^"_type_abbrevs"; b^"_terms"] in
-  export (n^"_term_abbrevs_part_1")
+  export (n^"_term_abbrevs")
     (deps @ if !use_sharing then [n^"_subterm_abbrevs"] else [])
     decl_term_abbrevs;
   if !use_sharing then
@@ -834,7 +834,8 @@ let iter_proofs_deps b f =
   f (b^"_terms");
   f (b^"_axioms");
   if !use_sharing then f (b^"_subterm_abbrevs");
-  for k = 1 to !abbrev_part do f (b^"_term_abbrevs"^part k) done
+  f (b^"_term_abbrevs");
+  for k = 2 to !abbrev_part do f (b^"_term_abbrevs"^part k) done
 ;;
 
 let export_proofs b r =

--- a/xprelude.ml
+++ b/xprelude.ml
@@ -34,6 +34,7 @@ let print_time =
 (* Maps on integers. *)
 module OrdInt = struct type t = int let compare = (-) end;;
 module MapInt = Map.Make(OrdInt);;
+module SetInt = Set.Make(OrdInt);;
 
 (* [map_thm_id_name] is used to hold the map from theorem numbers to
    theorem names. *)


### PR DESCRIPTION
- optimize dependencies of proof files
- term_abbrevs files are named from part_1
- Makefile: fix command for lpo.mk when there many files using xargs 

TODO:
- [x] remove log messages