### PR TITLE
generate term abbreviations in parallel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,21 +124,21 @@ jobs:
           make clean-lpo
           hol2dk resize thm75360.lp 100
           make -j3 lpo
-      - name: Test resize thm75360_term_abbrevs.lp 300
-        run: |
-          eval `opam env`
-          export HOL2DK_DIR=`pwd`
-          export HOLLIGHT_DIR=`pwd`/hol-light
-          cd output/xci
-          make clean-lpo
-          hol2dk resize thm75360_term_abbrevs.lp 300
-          make -j3 lpo
-      - name: Test resize thm75360_term_abbrevs.lp 100
-        run: |
-          eval `opam env`
-          export HOL2DK_DIR=`pwd`
-          export HOLLIGHT_DIR=`pwd`/hol-light
-          cd output/xci
-          make clean-lpo
-          hol2dk resize thm75360_term_abbrevs.lp 100
-          make -j3 lpo
+      # - name: Test resize thm75360_term_abbrevs.lp 300
+      #   run: |
+      #     eval `opam env`
+      #     export HOL2DK_DIR=`pwd`
+      #     export HOLLIGHT_DIR=`pwd`/hol-light
+      #     cd output/xci
+      #     make clean-lpo
+      #     hol2dk resize thm75360_term_abbrevs.lp 300
+      #     make -j3 lpo
+      # - name: Test resize thm75360_term_abbrevs.lp 100
+      #   run: |
+      #     eval `opam env`
+      #     export HOL2DK_DIR=`pwd`
+      #     export HOLLIGHT_DIR=`pwd`/hol-light
+      #     cd output/xci
+      #     make clean-lpo
+      #     hol2dk resize thm75360_term_abbrevs.lp 100
+      #     make -j3 lpo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,6 @@ jobs:
           hol2dk link xci
           make split
           make -j3 lp
-          make -j3 lp
           make -j3 v
           make -j3 lpo
       - name: Test --max-steps 250 and --max-abbrevs 200
@@ -106,9 +105,8 @@ jobs:
           cd output/xci
           make clean-lp
           make -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
-          make -j3 lp
           make -j3 lpo
-      - name: Check resize thm75360.lp 500
+      - name: Test resize thm75360.lp 500
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
@@ -117,7 +115,7 @@ jobs:
           make clean-lpo
           hol2dk resize thm75360.lp 500
           make -j3 lpo
-      - name: Check resize thm75360.lp 100
+      - name: Test resize thm75360.lp 100
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
@@ -126,7 +124,7 @@ jobs:
           make clean-lpo
           hol2dk resize thm75360.lp 100
           make -j3 lpo
-      - name: Check resize thm75360_term_abbrevs.lp 300
+      - name: Test resize thm75360_term_abbrevs.lp 300
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`
@@ -135,7 +133,7 @@ jobs:
           make clean-lpo
           hol2dk resize thm75360_term_abbrevs.lp 300
           make -j3 lpo
-      - name: Check resize thm75360_term_abbrevs.lp 100
+      - name: Test resize thm75360_term_abbrevs.lp 100
         run: |
           eval `opam env`
           export HOL2DK_DIR=`pwd`

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
           hol2dk link xci
           make split
           make -j3 lp
+          make -j3 lp
           make -j3 v
           make -j3 lpo
       - name: Test --max-steps 250 and --max-abbrevs 200
@@ -105,6 +106,7 @@ jobs:
           cd output/xci
           make clean-lp
           make -j3 HOL2DK_OPTIONS='--max-steps 250 --max-abbrevs 200' lp
+          make -j3 lp
           make -j3 lpo
       - name: Check resize thm75360.lp 500
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   abbreviations files.
   * The option --max-steps allows to fix the maximum number of proof
   steps in a proof file.
+- term abbreviations are now generated in parallel.
 - optimization of lp file dependencies in generated lp files.
 - generation of Makefile lpo dependencies at the same time as lp files.
 - Makefile: lpo and vo dependencies are recomputed automatically.
-- scripts to resize proof and term_abbrevs files without running hol2dk again
+- scripts to resize proof files without running hol2dk again
   (this is faster but dependencies may not be optimal).
 
 ## 1.0.0 (2024-02-25)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ STI_FILES := $(wildcard *.sti)
 MIN_FILES := $(wildcard *.min)
 
 .PHONY: lp
-lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp) $(MIN_FILES:%.min=%.lp)
+lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp) $(MIN_FILES:%.min=%.lp) $(MIN_FILES:%.min=%_type_abbrevs.lp)
 
 HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 1000000
 

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,19 @@ BASE_FILES := $(BASE)_types $(BASE)_terms $(BASE)_axioms
 $(BASE_FILES:%=%.lp) &:
 	hol2dk sig $(BASE).lp
 
+.PHONY: lp
+lp: lp-stage1
+	$(MAKE) lp-stage2
+
 STI_FILES := $(wildcard *.sti)
+
+.PHONY: lp-stage1
+lp-stage1: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp)
+
 MIN_FILES := $(wildcard *.min)
 
-.PHONY: lp
-lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp) $(MIN_FILES:%.min=%.lp) $(MIN_FILES:%.min=%_type_abbrevs.lp)
+.PHONY: lp-stage2
+lp-stage2: $(MIN_FILES:%.min=%.lp) $(MIN_FILES:%.min=%_type_abbrevs.lp)
 
 HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 1000000
 

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ FILES_WITH_SHARING = $(shell if test -f FILES_WITH_SHARING; then cat FILES_WITH_
 %.lp %.lpo.mk %.brv %.brp &: %.sti
 	hol2dk $(HOL2DK_OPTIONS) theorem $(BASE) $*.lp
 
-%.lp : %.min
+%.lp %_type_abbrevs.lp &: %.min
 	hol2dk abbrev $(BASE) $*.lp
 
 .PHONY: clean-lp
-clean-lp: clean-mk clean-min clean-max clean-brv clean-brp clean-lpo clean-v clean-vo
+clean-lp: clean-mk clean-min clean-brv clean-brp clean-lpo clean-v clean-vo
 	find . -maxdepth 1 -name '*.lp' -a ! -name theory_hol.lp -delete
 
 .PHONY: clean-mk
@@ -61,10 +61,6 @@ clean-mk:
 .PHONY: clean-min
 clean-min:
 	find . -maxdepth 1 -name '*.min' -delete
-
-.PHONY: clean-max
-clean-max:
-	find . -maxdepth 1 -name '*.max' -delete
 
 .PHONY: clean-brv
 clean-brv:

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 BASE = $(shell if test -f BASE; then cat BASE; fi)
 
-STI_FILES := $(wildcard *.sti)
-
 .PHONY: default
 default:
 	@echo "targets: split lp lpo v vo opam clean-<target> clean-all"
@@ -25,8 +23,11 @@ BASE_FILES := $(BASE)_types $(BASE)_terms $(BASE)_axioms
 $(BASE_FILES:%=%.lp) &:
 	hol2dk sig $(BASE).lp
 
+STI_FILES := $(wildcard *.sti)
+MIN_FILES := $(wildcard *.min)
+
 .PHONY: lp
-lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp)
+lp: $(BASE_FILES:%=%.lp) $(STI_FILES:%.sti=%.lp) $(MIN_FILES:%.min=%.lp)
 
 HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 1000000
 
@@ -34,17 +35,36 @@ FILES_WITH_SHARING = $(shell if test -f FILES_WITH_SHARING; then cat FILES_WITH_
 
 #$(FILES_WITH_SHARING:%=%.lp): HOL2DK_OPTIONS = --max-steps 100000 --max-abbrevs 20000 #--use-sharing
 
-%.lp %.lpo.mk &: %.sti
+%.lp %.lpo.mk %.brv %.brp &: %.sti
 	hol2dk $(HOL2DK_OPTIONS) theorem $(BASE) $*.lp
 
+%.lp : %.min
+	hol2dk abbrev $(BASE) $*.lp
+
 .PHONY: clean-lp
-clean-lp: clean-mk clean-lpo clean-v clean-vo
+clean-lp: clean-mk clean-min clean-max clean-brv clean-brp clean-lpo clean-v clean-vo
 	find . -maxdepth 1 -name '*.lp' -a ! -name theory_hol.lp -delete
 
 .PHONY: clean-mk
 clean-mk:
 	find . -maxdepth 1 -name '*.lpo.mk' -delete
 	rm -f lpo.mk vo.mk
+
+.PHONY: clean-min
+clean-min:
+	find . -maxdepth 1 -name '*.min' -delete
+
+.PHONY: clean-max
+clean-max:
+	find . -maxdepth 1 -name '*.max' -delete
+
+.PHONY: clean-brv
+clean-brv:
+	find . -maxdepth 1 -name '*.brv' -delete
+
+.PHONY: clean-brp
+clean-brp:
+	find . -maxdepth 1 -name '*.brp' -delete
 
 include lpo.mk
 

--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,12 @@ clean-brv:
 clean-brp:
 	find . -maxdepth 1 -name '*.brp' -delete
 
-include lpo.mk
-
 LP_FILES := $(wildcard *.lp)
 
-lpo.mk: $(LP_FILES:%.lp=%.lpo.mk)
+include lpo.mk
+
+lpo.mk: $(wildcard *.lpo.mk) #$(LP_FILES:%.lp=%.lpo.mk)
 	find . -maxdepth 1 -name '*.lpo.mk' | xargs cat > $@
-#	find . -maxdepth 1 -name '*.lp' -exec $(HOL2DK_DIR)/dep-lpo {} \; > lpo.mk
 
 theory_hol.lpo.mk: theory_hol.lp
 	$(HOL2DK_DIR)/dep-lpo $< > $@

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,16 +1,22 @@
 NOTES
 -----
 
+## 22/03/24
+
+generation of term abbreviations in parallel
+
+make lp-stage2 can be run in parallel of make lp-stage1 after some time
+
 ## 15/03/24
 
-optimizing dependencies:
+optimize dependencies on proofs too:
 
 hol.ml --max-abbrevs 20000: make -j32 lp 45s v 41s -j16 vo 37m28s
 hol.ml --max-abbrevs 10000: make -j32 lp 47s v 47s -j16 vo 42m30s
 
 ## 13/03/24
 
-optimizing dependencies on term_abbrevs:
+optimize dependencies on term_abbrevs:
 
 hol.ml --max-abbrevs 20000: make -j32 lp 42s v 41s -j16 vo 32m40s
 

--- a/README.md
+++ b/README.md
@@ -401,8 +401,8 @@ The part of HOL-Light that is aligned with Coq is gathered in the package
 [coq-hol-light](https://github.com/Deducteam/coq-hol-light) available
 in the Coq Opam repository [released](https://github.com/coq/opam).
 
-Performance
------------
+Performance on 25/02/24
+-----------------------
 
 Performance on a machine with 32 processors i9-13950HX and 64G RAM:
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 TODO
 ----
 
+- record times to generate proofs and term_abbrevs files of each theorem
+
 - share a single type_abbrev file ?
 
 - do hol2dk resize term_abbrevs in hol2dk using brv file

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,9 @@
 TODO
 ----
 
-- generate proof parts in parallel like with hol2dk mk
+- do hol2dk resize term_abbrevs in hol2dk using brv file
 
-- generate term_abbrevs parts in parallel by dumping the htable and then reading the dumped list in parallel
+- generate proof parts in parallel like with hol2dk mk
 
 - optimize number of let's (use a let only if an abbreviation is used more than once)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 TODO
 ----
 
+- share a single type_abbrev file ?
+
 - do hol2dk resize term_abbrevs in hol2dk using brv file
 
 - generate proof parts in parallel like with hol2dk mk

--- a/main.ml
+++ b/main.ml
@@ -89,8 +89,8 @@ hol2dk split $file
 hol2dk theorem $file $t.lp
   generate the lp proof of the theorem named $t
 
-hol2dk abbrev $file $t.lp $k
-  generate $t_term_abbrevs_part_$k
+hol2dk abbrev $file ${t}_term_abbrevs_part_$k.lp
+  generate ${t}_term_abbrevs_part_$k.lp
 
 Multi-threaded dk/lp file generation by splitting proofs in $n parts
 --------------------------------------------------------------------

--- a/main.ml
+++ b/main.ml
@@ -906,10 +906,7 @@ and command = function
          Xlp.export_theorem_proof n;
          close_in !Xproof.ic_prf;
          Xlp.dump_theorem_term_abbrevs n;
-         if !use_sharing then
-           Xlp.export (n^"_subterm_abbrevs")
-             [b^"_types"; b^"_terms"; n^"_type_abbrevs"]
-             Xlp.decl_subterm_abbrevs;
+         if !use_sharing then Xlp.export_subterm_abbrevs b n;
          Xlp.export_theorem_deps b n;
          Xlp.export_type_abbrevs b n;
          0

--- a/main.ml
+++ b/main.ml
@@ -89,6 +89,9 @@ hol2dk split $file
 hol2dk theorem $file $t.lp
   generate the lp proof of the theorem named $t
 
+hol2dk abbrev $file $t.lp $k
+  generate $t_term_abbrevs_part_$k
+
 Multi-threaded dk/lp file generation by splitting proofs in $n parts
 --------------------------------------------------------------------
 
@@ -164,7 +167,7 @@ let is_dk filename =
   | _ -> wrong_arg()
 
 let read_sig b =
-  let dump_file = b ^ ".sig" in
+  let dump_file = b^".sig" in
   let ic = open_in_bin dump_file in
   log "read %s ...\n%!" dump_file;
   the_type_constants := List.rev (input_value ic);
@@ -183,7 +186,7 @@ let integer s = try int_of_string s with Failure _ -> wrong_arg()
    between parts [dg]. *)
 let make nb_proofs dg b =
   let nb_parts = Array.length dg in
-  let dump_file = b ^ ".mk" in
+  let dump_file = b^".mk" in
   log "generate %s ...\n%!" dump_file;
   let oc = open_out dump_file in
   out oc "# file generated with: hol2dk mk %d %s\n" nb_parts b;
@@ -366,12 +369,12 @@ let print_hstats() =
     hstats (Hashtbl.stats Xlp.htbl_abbrev_part)
     hstats (Hashtbl.stats Xlp.htbl_abbrev_part_max)
 
-let valid_coq_filename s = match s with "at" -> "_" ^ s | _ -> s;;
+let valid_coq_filename s = match s with "at" -> "_"^s | _ -> s;;
 
 let call_script s args =
   match Sys.getenv_opt "HOL2DK_DIR" with
-  | None -> log "set $HOL2DK_DIR first"; 1
-  | Some d -> Sys.command (d ^ "/" ^ s ^ " " ^ String.concat " " args)
+  | None -> log "set $HOL2DK_DIR first\n"; 1
+  | Some d -> Sys.command (d^"/"^s^" "^String.concat " " args)
 ;;
 
 let print_env_var n =
@@ -381,7 +384,7 @@ let print_env_var n =
 ;;
 
 let rec log_command l =
-  log "\nhol2dk"; List.iter (log " %s") l; log " ...\n"; command l
+  log "\nhol2dk"; List.iter (log " %s") l; log " ...\n%!"; command l
 
 and dump_and_simp after_hol f =
   let b = basename_ml f in
@@ -440,7 +443,7 @@ and command = function
 
   | ["resize";f;k] ->
      let dk = is_dk f in
-     if dk then (log "dk output not available for this command"; 1)
+     if dk then (log "dk output not available for this command\n"; 1)
      else
        if String.ends_with ~suffix:"_term_abbrevs.lp" f then
          call_script "resize-term-abbrevs" [f;k]
@@ -452,9 +455,9 @@ and command = function
   | ["dump-simp-use";f] -> dump_and_simp false f
 
   | ["pos";b] ->
-     let nb_proofs = read_val (b ^ ".nbp") in
+     let nb_proofs = read_val (b^".nbp") in
      let pos = Array.make nb_proofs 0 in
-     let dump_file = b ^ ".prf" in
+     let dump_file = b^".prf" in
      log "read %s ...\n%!" dump_file;
      let ic = open_in_bin dump_file in
      let idx = ref 0 in
@@ -468,7 +471,7 @@ and command = function
        with End_of_file -> assert false
      end;
      close_in ic;
-     let dump_file = b ^ ".pos" in
+     let dump_file = b^".pos" in
      log "generate %s ...\n%!" dump_file;
      let oc = open_out_bin dump_file in
      output_value oc pos;
@@ -476,7 +479,7 @@ and command = function
      0
 
   | ["stat";b] ->
-     let nb_proofs = read_val (b ^ ".nbp") in
+     let nb_proofs = read_val (b^".nbp") in
      let thm_uses = Array.make nb_proofs 0 in
      let rule_uses = Array.make nb_rules 0 in
      let unused = ref 0 in
@@ -493,15 +496,15 @@ and command = function
      0
 
   | ["stat";b;s] ->
-     let nb_proofs = read_val (s ^ ".nbp") in
+     let nb_proofs = read_val (s^".nbp") in
      let thm_uses = Array.make nb_proofs 0 in
      let rule_uses = Array.make nb_rules 0 in
      let unused = ref 0 in
      read_use s;
-     let dump_file = b ^ ".prf" in
+     let dump_file = b^".prf" in
      log "read %s ...\n%!" dump_file;
      let ic = open_in_bin dump_file in
-     the_start_idx := read_val (s ^ ".sti");
+     the_start_idx := read_val (s^".sti");
      read_pos b;
      seek_in ic (get_pos !the_start_idx);
      let f k p =
@@ -516,7 +519,7 @@ and command = function
      print_rule_uses rule_uses (nb_proofs - !unused);
      0
 
-  | ["nbp";b] -> log "%#d proof steps\n" (read_val (b ^ ".nbp")); 0
+  | ["nbp";b] -> log "%#d proof steps\n" (read_val (b^".nbp")); 0
 
   | ["size";b] -> command ["size";b;"0"]
   | ["size";b;l] ->
@@ -549,12 +552,12 @@ and command = function
 
   | ["proof";b;x;y] ->
      let x = integer x and y = integer y in
-     let nb_proofs = read_val (b ^ ".nbp") in
+     let nb_proofs = read_val (b^".nbp") in
      if x < 0 || y < x || y >= nb_proofs then wrong_arg();
      read_pos b;
      init_proof_reading b;
      read_use b;
-     let map_thid_name = read_val (b ^ ".thm") in
+     let map_thid_name = read_val (b^".thm") in
      for k = x to y do
        log "%8d: %a" k proof (proof_at k);
        begin match Array.get !Xproof.last_use k with
@@ -573,7 +576,7 @@ and command = function
      read_pos b;
      init_proof_reading b;
      read_use b;
-     let dump_file = b ^ "-simp.prf" in
+     let dump_file = b^"-simp.prf" in
      log "generate %s ...\n%!" dump_file;
      let oc = open_out_bin dump_file in
      (* count the number of simplications *)
@@ -659,7 +662,7 @@ and command = function
      (* compute useful theorems *)
      read_pos b;
      init_proof_reading b;
-     let map_thid_name = read_val (b ^ ".thm") in
+     let map_thid_name = read_val (b^".thm") in
      let nb_proofs = Array.length !prf_pos in
      let useful = Array.make nb_proofs false in
      let rec mark_as_useful = function
@@ -680,7 +683,7 @@ and command = function
        (fun k b ->
          if b then decr nb_useless else Array.set !Xproof.last_use k (-1))
        useful;
-     let dump_file = b ^ ".use" in
+     let dump_file = b^".use" in
      log "generate %s ...\n" dump_file;
      let oc = open_out_bin dump_file in
      output_value oc !Xproof.last_use;
@@ -698,12 +701,12 @@ and command = function
      (* The .use file records an array [last_use] such that
         [last_use.(i) = 0] if [i] is a named theorem, the highest
         theorem index using [i] if there is one, and -1 otherwise. *)
-     let nb_proofs = read_val (b ^ ".nbp") in
+     let nb_proofs = read_val (b^".nbp") in
      let last_use = Array.make nb_proofs (-1) in
      read_prf b
        (fun i p -> List.iter (fun k -> Array.set last_use k i) (deps p));
-     MapInt.iter (fun k _ -> Array.set last_use k 0) (read_val (b ^ ".thm"));
-     let dump_file = b ^ ".use" in
+     MapInt.iter (fun k _ -> Array.set last_use k 0) (read_val (b^".thm"));
+     let dump_file = b^".use" in
      log "generate %s ...\n" dump_file;
      let oc = open_out_bin dump_file in
      output_value oc last_use;
@@ -722,7 +725,7 @@ and command = function
 
   | ["print";"use";b;k] ->
      let k = integer k in
-     let nb_proofs = read_val (b ^ ".nbp") in
+     let nb_proofs = read_val (b^".nbp") in
      if k < 0 || k >= nb_proofs then wrong_arg();
      read_use b;
      log "%d\n" (Array.get !Xproof.last_use k);
@@ -731,7 +734,7 @@ and command = function
   | ["mk";nb_parts;b] ->
      let nb_parts = integer nb_parts in
      if nb_parts < 2 then wrong_arg();
-     let nb_proofs = read_val (b ^ ".nbp") in
+     let nb_proofs = read_val (b^".nbp") in
      let part_size = nb_proofs / nb_parts in
      let part idx =
        let k = idx / part_size in
@@ -763,7 +766,7 @@ and command = function
        done;
        log "\n"
      done;
-     let dump_file = b ^ ".dg" in
+     let dump_file = b^".dg" in
      log "generate %s ...\n%!" dump_file;
      let oc = open_out_bin dump_file in
      output_value oc nb_parts;
@@ -793,12 +796,12 @@ and command = function
      let dk = is_dk f in
      let b = Filename.chop_extension f in
      read_sig b;
-     let map_thid_name = read_val (b ^ ".thm") in
+     let map_thid_name = read_val (b^".thm") in
      read_pos b;
      init_proof_reading b;
      begin
        if dk then Xdk.export_theorems b map_thid_name
-       else let nb_parts = read_val (b ^ ".dg") in
+       else let nb_parts = read_val (b^".dg") in
             Xlp.export_theorems_part nb_parts b map_thid_name
      end;
      close_in !Xproof.ic_prf;
@@ -808,7 +811,7 @@ and command = function
      let dk = is_dk f in
      let b = Filename.chop_extension f in
      read_sig b;
-     let map_thid_name = read_val (b ^ ".thm") in
+     let map_thid_name = read_val (b^".thm") in
      read_pos b;
      init_proof_reading b;
      begin
@@ -821,7 +824,7 @@ and command = function
   | ["part";k;x;y;f] ->
      let b = Filename.chop_extension f in
 
-     let dump_file = b ^ ".dg" in
+     let dump_file = b^".dg" in
      log "read %s ...\n%!" dump_file;
      let ic = open_in_bin dump_file in
      let nb_parts = input_value ic in
@@ -853,19 +856,19 @@ and command = function
      read_pos b;
      read_use b;
      (*init_proof_reading b;*)
-     let map_thid_name = read_val (b ^ ".thm") in
+     let map_thid_name = read_val (b^".thm") in
      let map = ref MapInt.empty in
      let create_segment start_index end_index =
        let n = try valid_coq_filename (MapInt.find end_index map_thid_name)
-               with Not_found -> "thm" ^ string_of_int end_index in
+               with Not_found -> "thm"^string_of_int end_index in
        let len = end_index - start_index + 1 in
-       write_val (n ^ ".nbp") len;
-       write_val (n ^ ".sti") start_index;
-       write_val (n ^ ".pos") (Array.sub !prf_pos start_index len);
-       write_val (n ^ ".use") (Array.sub !last_use start_index len);
+       write_val (n^".nbp") len;
+       write_val (n^".sti") start_index;
+       write_val (n^".pos") (Array.sub !prf_pos start_index len);
+       write_val (n^".use") (Array.sub !last_use start_index len);
        let p = Array.get !prf_pos end_index in
        map := MapInt.add end_index (n,p) !map;
-       (*let dump_file = n ^ ".prf" in
+       (*let dump_file = n^".prf" in
        log "write %s ...\n%!" dump_file;
        let oc = open_out_bin dump_file in
        seek_in !ic_prf (get_pos start_index);
@@ -887,28 +890,58 @@ and command = function
      done;
      create_segment 0 !end_idx;
      (*MapInt.iter (fun i (n,_) -> log "%d %s\n" i n) !map;*)
-     write_val (b ^ ".thp") !map;
+     write_val (b^".thp") !map;
      0
 
   | ["theorem";b;f] ->
      read_sig b;
-     map_thid_pos := read_val (b ^ ".thp");
+     map_thid_pos := read_val (b^".thp");
      let n = Filename.chop_extension f in
      read_pos n;
      read_use n;
-     the_start_idx := read_val (n ^ ".sti");
+     the_start_idx := read_val (n^".sti");
      (*log "the_start_idx = %d\n%!" !the_start_idx;*)
      init_proof_reading b;
-     if is_dk f then (log "dk output not available for this command"; 1)
+     if is_dk f then (log "dk output not available for this command\n"; 1)
      else
        begin
          Xlp.export_theorem_proof n;
          close_in !Xproof.ic_prf;
-         Xlp.export_theorem_term_abbrevs b n;
+         Xlp.dump_theorem_term_abbrevs n;
+         if !use_sharing then
+           Xlp.export (n^"_subterm_abbrevs")
+             [b^"_types"; n^"_type_abbrevs"; b^"_terms"]
+             Xlp.decl_subterm_abbrevs;
          Xlp.export_theorem_deps b n;
          Xlp.export_type_abbrevs b n;
          0
        end
+
+  | ["abbrev";b;f] ->
+     begin
+       try
+         let dk = is_dk f in
+         let s = Filename.chop_extension f in
+         let len = String.length s in
+         let i = ref (len - 1) in
+         let k = (* compute part number *)
+           while !i >= 0 && s.[!i] <> '_' do decr i done;
+           if !i < 0 then raise Exit;
+           integer (String.sub s (!i+1) (len - 1 - !i))
+         in
+         (* compute theorem name *)
+         if !i < 17 then raise Exit;
+         let n = String.sub s 0 (!i - 18) in
+         if dk then (log "dk output not available for this command\n"; 1)
+         else
+           begin
+             read_sig b;
+             map_thid_pos := read_val (b^".thp");
+             Xlp.export_theorem_term_abbrevs b n k;
+             0
+           end;
+       with Exit -> log "invalid argument\n"; 1
+     end
 
   | f::args ->
      let r = range args in
@@ -934,24 +967,23 @@ and command = function
      if dk then
        begin
          Xdk.export_proofs b r;
-         if r = All then Xdk.export_theorems b (read_val (b ^ ".thm"));
+         if r = All then Xdk.export_theorems b (read_val (b^".thm"));
          Xdk.export_term_abbrevs b;
          Xdk.export_type_abbrevs b;
          log "generate %s.dk ...\n%!" b;
          let infiles =
-           List.map (fun s -> b ^ "_" ^ s ^ ".dk")
+           List.map (fun s -> b^"_"^s^".dk")
              (["types";"type_abbrevs";"terms";"term_abbrevs";"axioms"
               ;"proofs"] @ if r = All then ["theorems"] else [])
          in
          exit
            (Sys.command
-              ("cat theory_hol.dk " ^ String.concat " " infiles
-               ^ " > " ^ b ^ ".dk"))
+              ("cat theory_hol.dk "^String.concat " " infiles^" > "^b^".dk"))
        end
      else
        begin
          Xlp.export_proofs b r;
-         if r = All then Xlp.export_theorems b (read_val (b ^ ".thm"));
+         if r = All then Xlp.export_theorems b (read_val (b^".thm"));
          Xlp.export_term_abbrevs_in_one_file b b;
          Xlp.export_type_abbrevs b b
        end;

--- a/main.ml
+++ b/main.ml
@@ -900,7 +900,6 @@ and command = function
      read_pos n;
      read_use n;
      the_start_idx := read_val (n^".sti");
-     (*log "the_start_idx = %d\n%!" !the_start_idx;*)
      init_proof_reading b;
      if is_dk f then (log "dk output not available for this command\n"; 1)
      else
@@ -910,7 +909,7 @@ and command = function
          Xlp.dump_theorem_term_abbrevs n;
          if !use_sharing then
            Xlp.export (n^"_subterm_abbrevs")
-             [b^"_types"; n^"_type_abbrevs"; b^"_terms"]
+             [b^"_types"; b^"_terms"; n^"_type_abbrevs"]
              Xlp.decl_subterm_abbrevs;
          Xlp.export_theorem_deps b n;
          Xlp.export_type_abbrevs b n;

--- a/main.ml
+++ b/main.ml
@@ -120,9 +120,6 @@ hol2dk env
 hol2dk nbp $file
   print the number of proof steps in $file.prf
 
-hol2dk resize $file_term_abbrevs.lp $n
-  rebuild the term abbreviation files of $file.lp with --max-abbrevs $n
-
 hol2dk resize $file.lp $n
   rebuild the proof files of $file.lp with --max-steps $n
 
@@ -441,13 +438,15 @@ and command = function
   | ["unpatch" as s] -> call_script s []
   | ["link";arg] -> call_script "add-links" [arg]
 
+(*hol2dk resize $file_term_abbrevs.lp $n
+  rebuild the term abbreviation files of $file.lp with --max-abbrevs $n*)
   | ["resize";f;k] ->
      let dk = is_dk f in
      if dk then (log "dk output not available for this command\n"; 1)
      else
-       if String.ends_with ~suffix:"_term_abbrevs.lp" f then
+       (*if String.ends_with ~suffix:"_term_abbrevs.lp" f then
          call_script "resize-term-abbrevs" [f;k]
-       else call_script "resize-proof" [f;k]
+       else*) call_script "resize-proof" [f;k]
 
   | ["dump";f] -> dump true f (basename_ml f)
   | ["dump-use";f] -> dump false f (basename_ml f)

--- a/xlib.ml
+++ b/xlib.ml
@@ -83,7 +83,7 @@ let read_val dump_file =
 
 (* [write_val f v] write [v] in file [f]. *)
 let write_val dump_file v =
-  log "write %s ...\n%!" dump_file;
+  log "generate %s ...\n%!" dump_file;
   let oc = open_out_bin dump_file in
   output_value oc v;
   close_out oc

--- a/xlib.ml
+++ b/xlib.ml
@@ -11,6 +11,8 @@ open Fusion
 
 let open_file n = log "generate %s ...\n%!" n; open_out n;;
 
+let create_file n f = let oc = open_file n in f oc; close_out oc;;
+
 let command s =
   if Sys.command s <> 0 then (log "Error: \"%s\" failed.\n" s; exit 1);;
 

--- a/xlib.ml
+++ b/xlib.ml
@@ -134,6 +134,7 @@ let rec change_prefixes l s =
 
 (* [bindings ht] returns the list of bindings in the hash table [ht]. *)
 let bindings ht = Hashtbl.fold (fun x y acc -> (x,y)::acc) ht [];;
+let sorted_bindings ht = List.sort Stdlib.compare (bindings ht);;
 
 (****************************************************************************)
 (* Printing functions. *)
@@ -158,17 +159,18 @@ let list_sep sep elt oc xs =
 ;;
 
 let list elt oc xs = list_sep "" elt oc xs;;
-
 let olist elt oc xs = out oc "[%a]" (list_sep "; " elt) xs;;
-
-let set_int oc s = olist int oc (SetInt.elements s);;
-let set_str oc s = olist string oc (SetStr.elements s);;
-
 let list_prefix p elt oc xs = list (prefix p elt) oc xs;;
+
+let array elt oc a =
+  out oc "["; Array.iter (fun x -> out oc "%a;" elt x) a; out oc "]";;
+
+let set_int oc s = out oc "{"; SetInt.iter (out oc "%d;") s; out oc "}";;
+let set_str oc s = out oc "{"; SetStr.iter (out oc "%s;") s; out oc "}";;
 
 let htbl ppkey ppval oc ht =
   (*Hashtbl.iter (opair oc)*)
-  List.iter (opair ppkey ppval oc) (List.sort Stdlib.compare (bindings ht));;
+  List.iter (opair ppkey ppval oc) (sorted_bindings ht);;
 
 let hstats oc hs =
   let open Hashtbl in

--- a/xlp.ml
+++ b/xlp.ml
@@ -700,38 +700,6 @@ let dump_theorem_term_abbrevs n =
   Hashtbl.iter (fun k m -> write_val (f k^".max") (m,0)) htbl_abbrev_part_max
 ;;
 
-(* [export_theorem_term_abbrevs b n] writes the term abbreviations in
-   the files [n^"_term_abbrevs"^part(k)^".lp"]. *)
-(*let export_theorem_term_abbrevs b n =
-  let l = TrmHashtbl.fold (fun t x acc -> (t,x)::acc) htbl_term_abbrev [] in
-  let cmp (_,(k1,_,_)) (_,(k2,_,_)) = Stdlib.compare k1 k2 in
-  let l = ref (List.sort cmp l) in
-  let iter_deps f =
-    f (b^"_types");
-    f (n^"_type_abbrevs");
-    f (b^"_terms");
-    if !use_sharing then f (n^"_subterm_abbrevs")
-  in
-  let part_abbrev (i,min) =
-    let abbrevs oc =
-      let max =
-        try Hashtbl.find htbl_abbrev_part_max i with Not_found -> assert false
-      in
-      for _ = min to max do
-        match !l with
-        | [] -> assert false
-        | (t,x)::l' -> decl_term_abbrev oc t x; l := l'
-      done
-    in
-    export_iter (n^"_term_abbrevs"^part i) iter_deps abbrevs
-  in
-  List.iter part_abbrev
-    (List.sort Stdlib.compare (Xlib.bindings htbl_abbrev_part_min));
-  if !use_sharing then
-    export (n^"_subterm_abbrevs") [b^"_types"; n^"_type_abbrevs"; b^"_terms"]
-      decl_subterm_abbrevs
-;;*)
-
 (* [export_theorem_term_abbrevs b n k] writes the term abbreviations
    file [n^"_term_abbrevs"^part(k)^".lp"]. *)
 let export_theorem_term_abbrevs b n k =

--- a/xlp.ml
+++ b/xlp.ml
@@ -112,7 +112,6 @@ let typ = abbrev_typ;;
 (* [decl_type_abbrevs oc] outputs on [oc] the type abbreviations. *)
 let decl_type_abbrevs oc =
   let abbrev b (k,n) =
-    log "symbol type%d\n%!" k;
     out oc "symbol type%d" k;
     for i=0 to n-1 do out oc " a%d" i done;
     (* We can use [raw_typ] here since [b] is canonical. *)
@@ -673,8 +672,9 @@ let export_term_abbrevs_in_one_file b n =
     export (n^"_subterm_abbrevs") deps decl_subterm_abbrevs
 ;;
 
-(* [dump_theorem_term_abbrevs n] writes the term abbreviations in
-   the file [n^"_term_abbrevs.brv"]. *)
+(* [dump_theorem_term_abbrevs n] generates the files
+   [n^"_term_abbrevs.brv"], [n^"_term_abbrevs.min"] and
+   [n^"_term_abbrevs.max"]. *)
 let dump_theorem_term_abbrevs n =
   let l = TrmHashtbl.fold (fun t x acc -> (t,x)::acc) htbl_term_abbrev [] in
   let cmp (_,(k1,_,_)) (_,(k2,_,_)) = Stdlib.compare k1 k2 in
@@ -700,7 +700,7 @@ let dump_theorem_term_abbrevs n =
   Hashtbl.iter (fun k m -> write_val (f k^".max") (m,0)) htbl_abbrev_part_max
 ;;
 
-(* [export_theorem_term_abbrevs b n k] writes the term abbreviations
+(* [export_theorem_term_abbrevs b n k] writes the term abbreviation
    file [n^"_term_abbrevs"^part(k)^".lp"]. *)
 let export_theorem_term_abbrevs b n k =
   let pos : int array = read_val (n^".brp")

--- a/xlp.ml
+++ b/xlp.ml
@@ -718,7 +718,7 @@ let dump_theorem_term_abbrevs n =
       for _ = min to max do
         match !l with
         | [] -> assert false
-        | (t,x)::l' -> abbrev oc t x; l := l'
+        | (t,x)::l' -> decl_abbrev oc t x; l := l'
       done
     in
     export_iter (n^"_term_abbrevs"^part i) iter_deps abbrevs

--- a/xlp.ml
+++ b/xlp.ml
@@ -112,6 +112,7 @@ let typ = abbrev_typ;;
 (* [decl_type_abbrevs oc] outputs on [oc] the type abbreviations. *)
 let decl_type_abbrevs oc =
   let abbrev b (k,n) =
+    log "symbol type%d\n%!" k;
     out oc "symbol type%d" k;
     for i=0 to n-1 do out oc " a%d" i done;
     (* We can use [raw_typ] here since [b] is canonical. *)
@@ -673,7 +674,7 @@ let dump_theorem_term_abbrevs n =
   let cmp (_,(k1,_,_)) (_,(k2,_,_)) = Stdlib.compare k1 k2 in
   let l = List.sort cmp l in
   let dump_file = n^".brv" in
-  log "write %s ...\n%!" dump_file;
+  log "generate %s ...\n%!" dump_file;
   let oc = open_out_bin dump_file in
   List.iter (output_value oc) l;
   close_out oc;
@@ -688,7 +689,7 @@ let dump_theorem_term_abbrevs n =
   close_in ic;
   write_val (n^".brp") pos;
   write_val (n^".brt") htbl_type_abbrev;
-  (* For some reason, writing of just m doesn't work! Hence, the pair. *)
+  (* For some reason, writing just m doesn't work! Hence, the pair. *)
   Hashtbl.iter
     (fun k m -> write_val (n^"_term_abbrevs"^part k^".min") (m,0))
     htbl_abbrev_part_min;
@@ -736,8 +737,6 @@ let export_theorem_term_abbrevs b n k =
   and min : int = fst (read_val (n^"_term_abbrevs"^part k^".min"))
   and max : int = fst (read_val (n^"_term_abbrevs"^part k^".max"))
   and ht : (int * int) TypHashtbl.t = read_val (n^".brt") in
-  (*let get_val = function Some x -> x | None -> assert false in
-  let max = get_val max and min = get_val min in*)
   TypHashtbl.iter (fun b v ->
       let _tvs, b = canonical_typ b in
       TypHashtbl.add htbl_type_abbrev b v) ht;

--- a/xlp.ml
+++ b/xlp.ml
@@ -846,7 +846,7 @@ let export_proofs_in_interval n x y =
 let export_theorem_proof n =
   export_proofs_in_interval n !the_start_idx
     (!the_start_idx + Array.length !prf_pos - 1);
-  log "rename %s_part_%d_proofs.lp into %s.lp ...\n%!" n !proof_part n;
+  log "rename %s_part_%d_proofs.lp into %s_proofs.lp ...\n%!" n !proof_part n;
   command
     (Printf.sprintf "mv -f %s_part_%d_proofs.lp %s_proofs.lp" n !proof_part n)
 ;;

--- a/xlp.ml
+++ b/xlp.ml
@@ -827,7 +827,7 @@ let export_proofs_in_interval n x y =
 ;;
 
 (* [export_theorem_proof n] generates the files
-   [n^part(k)^"_proofs.lp"] for some [1<=k<!proof_part] and the file
+   [n^part(k)^"_proofs.lp"] for [1<=k<!proof_part] and the file
    [n^"_proofs.lp"]. *)
 let export_theorem_proof n =
   export_proofs_in_interval n !the_start_idx

--- a/xlp.ml
+++ b/xlp.ml
@@ -306,20 +306,21 @@ let term rmap oc t = abbrev_term oc (rename rmap t);;
   else unabbrev_term rmap oc (rename rmap t);;*)
 
 (****************************************************************************)
-(* Handling of file dependencies. *)
+(* Handling file dependencies. *)
 (****************************************************************************)
 
 let require oc n = out oc "require open hol-light.%s;\n" n;;
 
-(* [create n iter_deps] creates a file [n^".lp"] and returns its
-   out_channel. It also adds in it require commands following the
-   dependency iterator [iter_deps], and creates the files
-   [n^".lpo.mk"] and [n^".vo.mk"] to record the dependencies of
-   [n^".lpo"] and [n^".vo"] respectively. *)
-let create (p:string) (iter_deps:(string->unit)->unit) =
-  let oc_lp = open_file (p^".lp")
-  and oc_lpo_mk = open_file (p^".lpo.mk") in
-  out oc_lpo_mk "%s.lpo:" p;
+(* [create_file_with_deps tmp n iter_deps f] creates a file
+   [tmp^".lp"], which will be renamed or included in [n^".lp"] in the
+   end, and writes in it require commands following the dependency
+   iterator [iter_deps], followed by [f]. It also creates the file
+   [n^".lpo.mk"] to record the dependencies of [n^".lpo"]. *)
+let create_file_with_deps (tmp:string) (n:string)
+      (iter_deps:(string->unit)->unit) (f:out_channel->unit) =
+  let oc_lp = open_file (tmp^".lp")
+  and oc_lpo_mk = open_file (n^".lpo.mk") in
+  out oc_lpo_mk "%s.lpo:" n;
   let handle dep =
     require oc_lp dep;
     out oc_lpo_mk " %s.lpo" dep;
@@ -328,14 +329,14 @@ let create (p:string) (iter_deps:(string->unit)->unit) =
   iter_deps handle;
   out oc_lpo_mk "\n";
   close_out oc_lpo_mk;
-  oc_lp
+  f oc_lp;
+  close_out oc_lp
 ;;
 
-let export_iter p iter_deps f =
-  let oc = create p iter_deps in f oc; close_out oc
+let export_iter n = create_file_with_deps n n;;
 ;;
 
-let export p deps = export_iter p (fun h -> List.iter h deps);;
+let export n deps = export_iter n (fun h -> List.iter h deps);;
 
 (****************************************************************************)
 (* Translation of term abbreviations. *)
@@ -663,6 +664,11 @@ let export_type_abbrevs b n =
   export (n^"_type_abbrevs") [b^"_types"] decl_type_abbrevs
 ;;
 
+let export_subterm_abbrevs b n =
+  export (n^"_subterm_abbrevs") [b^"_types"; b^"_terms"; n^"_type_abbrevs"]
+    decl_subterm_abbrevs
+;;
+
 let export_term_abbrevs_in_one_file b n =
   let deps = [b^"_types"; n^"_type_abbrevs"; b^"_terms"] in
   export (n^"_term_abbrevs")
@@ -709,28 +715,35 @@ let dump_theorem_term_abbrevs n =
 (* [export_theorem_term_abbrevs b n k] writes the term abbreviation
    file [n^"_term_abbrevs"^part(k)^".lp"]. *)
 let export_theorem_term_abbrevs b n k =
+  let p = n^"_term_abbrevs"^part k in
+  (* generate [p^"_tail.lp"] *)
   let pos : int array = read_val (n^".brp")
-  and (min, max) : int * int = read_val (n^"_term_abbrevs"^part k^".min") in
+  and (min, max) : int * int = read_val (p^".min") in
   let dump_file = n^".brv" in
   log "read %s ...\n%!" dump_file;
   let ic = open_in_bin dump_file in
   if max >= 0 then seek_in ic pos.(min);
-  let p = n^"_term_abbrevs"^part k in
-  let iter_deps f =
-    f (b^"_types");
-    f (b^"_terms");
-    f (p^"_type_abbrevs");
-    if !use_sharing then f (n^"_subterm_abbrevs")
-  in
-  let abbrevs oc =
+  let term_abbrevs oc =
     for _ = min to max do
       let t,x = input_value ic in
       decl_term_abbrev oc t x
     done
   in
-  export_iter p iter_deps abbrevs;
+  create_file (p^"_tail.lp") term_abbrevs;
   close_in ic;
-  export_type_abbrevs b p
+  (* generate [p^"_type_abbrevs.lp"] *)
+  let iter_deps f = f (b^"_types") in
+  export_iter (p^"_type_abbrevs") iter_deps decl_type_abbrevs;
+  (* generate [p^"_head.lp"] *)
+  let iter_deps f =
+    f (b^"_types");
+    f (b^"_terms");
+    f (p^"_type_abbrevs");
+    if !use_sharing then f (p^"_subterm_abbrevs")
+  in
+  create_file_with_deps (p^"_head") p iter_deps (fun _ -> ());
+  (* generate [p^".lp"] *)
+  concat (p^"_head.lp") (p^"_tail.lp") (p^".lp")
 ;;
 
 (****************************************************************************)
@@ -824,33 +837,25 @@ let export_theorem_proof n =
     (Printf.sprintf "mv -f %s_part_%d_proofs.lp %s_proofs.lp" n !proof_part n)
 ;;
 
-(* [export_theorem_deps n] generates for [1<=i<=!proof_part] the files
+(* [export_theorem_deps b n] generates for [1<=i<=!proof_part] the files
    [n^part(i)^"_deps.lp"] and [n^part(i)^".lp"] assuming that the files
    [n^part(i)^"_proofs.lp"] are already generated. *)
 let export_theorem_deps b n =
   for i = 1 to !proof_part do
     let p = if i < !proof_part then n^part i else n in
-    let oc_lp = open_file (p^"_deps.lp")
-    and oc_lpo_mk = open_file (p^".lpo.mk") in
-    out oc_lpo_mk "%s.lpo:" p;
-    let f dep =
-      require oc_lp dep;
-      out oc_lpo_mk " %s.lpo" dep;
+    let iter_deps f =
+      f (b^"_types");
+      f (b^"_terms");
+      f (b^"_axioms");
+      f (n^"_type_abbrevs");
+      if !use_sharing then f (n^"_subterm_abbrevs");
+      SetInt.iter (fun j -> f (n^"_term_abbrevs"^part j))
+        (Hashtbl.find htbl_abbrev_deps i);
+      SetInt.iter (fun j -> f (n^part j)) (Hashtbl.find htbl_proof_deps i);
+      SetStr.iter f (Hashtbl.find htbl_thm_deps i);
     in
-    f "theory_hol";
-    f (b^"_types");
-    f (b^"_terms");
-    f (b^"_axioms");
-    f (n^"_type_abbrevs");
-    if !use_sharing then f (n^"_subterm_abbrevs");
-    SetInt.iter (fun j -> f (n^"_term_abbrevs"^part j))
-      (Hashtbl.find htbl_abbrev_deps i);
-    SetInt.iter (fun j -> f (n^part j)) (Hashtbl.find htbl_proof_deps i);
-    SetStr.iter f (Hashtbl.find htbl_thm_deps i);
-    close_out oc_lp;
-    out oc_lpo_mk "\n";
-    close_out oc_lpo_mk;
-    concat (p^"_deps.lp") (p^"_proofs.lp") (p^".lp");
+    create_file_with_deps (p^"_deps") p iter_deps (fun _ -> ());
+    concat (p^"_deps.lp") (p^"_proofs.lp") (p^".lp")
   done
 ;;
 


### PR DESCRIPTION
The generation of term abbreviations is separated from the generation of proofs.
Each term abbreviation file now has its own type abbreviation file.
Because of this resize-term-abbrevs is not valid anymore. So the command has been commented.