### PR TITLE
generate dump files only with command dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ On a machine with 32 processors i9-13950HX and 64G RAM with HOL-Light ea45176, H
 
 | HOL-Light file | dump  | size | steps | thms | lp  | v   | size | vo     |
 |----------------|-------|------|-------|------|-----|-----|------|--------|
-| hol.ml         | 3m57s | 3 Gb | 3 M   | 5687 | 39s | 37s | 1 Gb | 56m23s |
+| hol.ml         | 3m57s | 3 Gb | 3 M   | 5687 | 39s | 34s | 1 Gb | 56m23s |
 
 Performance without the mapping of real numbers (hol2dk 2.0)
 ------------------------------------------------------------

--- a/fusion.ml
+++ b/fusion.ml
@@ -14,7 +14,7 @@ open Lib
 
 module type Hol_kernel =
   sig
-    type hol_type =
+      type hol_type =
       (*REMOVE
       private
       REMOVE*)
@@ -66,6 +66,10 @@ module type Hol_kernel =
 
       type proof = Proof of (thm * proof_content)
 
+      val index_of : thm -> int
+      val content_of : proof -> proof_content
+      val change_content : proof -> proof_content -> proof
+
       val types: unit -> (string * int)list
       val get_type_arity : string -> int
       (*REMOVE
@@ -116,9 +120,6 @@ module type Hol_kernel =
       val dest_thm : thm -> term list * term
       val hyp : thm -> term list
       val concl : thm -> term
-      val index_of : thm -> int
-      val content_of : proof -> proof_content
-      val change_content : proof -> proof_content -> proof
       (*REMOVE
       val REFL : term -> thm
       val TRANS : thm -> thm -> thm
@@ -130,6 +131,12 @@ module type Hol_kernel =
       val DEDUCT_ANTISYM_RULE : thm -> thm -> thm
       val INST_TYPE : (hol_type * hol_type) list -> thm -> thm
       val INST : (term * term) list -> thm -> thm
+      val axioms : unit -> thm list
+      val new_axiom : term -> thm
+      val definitions : unit -> thm list
+      val new_basic_definition : term -> thm
+      val new_basic_type_definition :
+              string -> string * string -> thm -> thm * thm
 
       (*START_ND*)
       val TRUTH : thm
@@ -153,15 +160,8 @@ module type Hol_kernel =
       val new_theorem : term list -> term -> proof_content -> thm
       val dump_nb_proofs : string -> unit
       val dump_signature : string -> unit
-      REMOVE*)
-      val axioms : unit -> thm list
-      val new_axiom : term -> thm
-      val definitions : unit -> thm list
-      val new_basic_definition : term -> thm
-      val new_basic_type_definition :
-              string -> string * string -> thm -> thm * thm
-      val dump_filename : string
       val oc_dump : out_channel
+      REMOVE*)
       (*REMOVE*)val the_type_constants : (string * int) list ref
       (*REMOVE*)val the_term_constants : (string * hol_type) list ref
       (*REMOVE*)val the_axioms : thm list ref
@@ -184,6 +184,7 @@ module Hol : Hol_kernel = struct
 
 
   type thm = Sequent of (term list * term * int)
+  (*REMOVE*)let dummy_thm = Sequent([],Var("x",Tyvar("a")),0)
 
 (*---------------------------------------------------------------------------*)
 (* Proof dumping.                                                            *)
@@ -224,9 +225,8 @@ module Hol : Hol_kernel = struct
   let change_content p c = let Proof(th,_) = p in Proof(th,c)
 
   let thm_index = ref (-1)
-
-  let dump_filename = Printf.sprintf "dump%d.prf" (Unix.getpid())
-  let oc_dump = open_out_bin dump_filename
+  (*REMOVE
+  let oc_dump = open_out_bin "dump.prf"
 
   let new_theorem hyps concl proof_content =
     let k = !thm_index + 1 in
@@ -235,7 +235,7 @@ module Hol : Hol_kernel = struct
     output_value oc_dump (Proof(thm,proof_content));
     thm
   ;;
-
+  REMOVE*)
 (* ------------------------------------------------------------------------- *)
 (* List of current type constants with their arities.                        *)
 (*                                                                           *)
@@ -626,10 +626,11 @@ module Hol : Hol_kernel = struct
 
   let index_of (Sequent(_,_,k)) = k
 
+(*REMOVE
 (* ------------------------------------------------------------------------- *)
 (* Basic equality properties; TRANS is derivable but included for efficiency *)
 (* ------------------------------------------------------------------------- *)
-(*REMOVE
+
   let REFL tm = new_theorem [] (safe_mk_eq tm tm) (Prefl tm)
 
   let TRANS (Sequent(asl1,c1,k1)) (Sequent(asl2,c2,k2)) =
@@ -821,7 +822,7 @@ REMOVE*)
 (* ------------------------------------------------------------------------- *)
 
   let the_axioms = ref ([]:thm list)
-
+(*REMOVE
   let axioms() = !the_axioms
 
   let new_axiom tm =
@@ -829,13 +830,13 @@ REMOVE*)
       let th = new_theorem [] tm (Paxiom tm) in
       (the_axioms := th::(!the_axioms); th)
     else failwith "new_axiom: Not a proposition"
-
+REMOVE*)
 (* ------------------------------------------------------------------------- *)
 (* Handling of (term) definitions.                                           *)
 (* ------------------------------------------------------------------------- *)
 
   let the_definitions = ref ([]:thm list)
-
+(*REMOVE
   let definitions() = !the_definitions
 
   let new_basic_definition tm =
@@ -851,7 +852,7 @@ REMOVE*)
              let dth = new_theorem [] dtm (Pdef(dtm,cname,ty)) in
              (the_definitions := dth::(!the_definitions); dth)
     | _ -> failwith "new_basic_definition"
-
+REMOVE*)
 (* ------------------------------------------------------------------------- *)
 (* Handling of type definitions.                                             *)
 (*                                                                           *)
@@ -864,7 +865,7 @@ REMOVE*)
 (*                                                                           *)
 (* Where "abs" and "rep" are new constants with the nominated names.         *)
 (* ------------------------------------------------------------------------- *)
-
+(*REMOVE
   let new_basic_type_definition tyname (absname,repname) (Sequent(asl,c,p)) =
     if exists (can get_const_type) [absname; repname] then
       failwith "new_basic_type_definition: Constant(s) already in use" else
@@ -916,7 +917,7 @@ REMOVE*)
     output_value oc (definitions());
     close_out oc
   ;;
-
+REMOVE*)
 end;;
 
 include Hol;;

--- a/main.ml
+++ b/main.ml
@@ -343,7 +343,7 @@ let range args =
 ;;
 
 let dump after_hol f b =
-  let ml_file = Printf.sprintf "dump%d.ml" (Unix.getpid()) in
+  let ml_file = "dump.ml" in
   log_gen ml_file;
   let oc = open_out ml_file in
   let use oc after_hol =
@@ -360,7 +360,7 @@ let dump after_hol f b =
 #require "unix";;
 %a
 close_out oc_dump;;
-Sys.command ("mv "^dump_filename^" %s.prf");;
+Sys.command ("mv -f dump.prf %s.prf");;
 dump_nb_proofs "%s.nbp";;
 dump_signature "%s.sig";;
 #load "str.cma";;

--- a/xdk.ml
+++ b/xdk.ml
@@ -475,7 +475,7 @@ let proof tvs rmap =
        end
     | Paxiom(t) ->
        let k =
-         try pos_first (fun th -> concl th = t) (axioms())
+         try pos_first (fun th -> concl th = t) !the_axioms
          with Not_found -> assert false
        in
        string oc "axiom_"; int oc k;
@@ -483,7 +483,7 @@ let proof tvs rmap =
        list_prefix " " term oc (frees t)
     | Pdeft(_,t,_,_) ->
        let k =
-         try pos_first (fun th -> concl th = t) (axioms())
+         try pos_first (fun th -> concl th = t) !the_axioms
          with Not_found -> assert false
        in
        string oc "axiom_"; int oc k;
@@ -787,9 +787,9 @@ let export_axioms b =
   export (b^"_axioms")
     (fun oc ->
       string oc "\n(; axioms ;)\n";
-      decl_axioms oc (axioms());
+      decl_axioms oc !the_axioms;
       string oc "\n(; definitional axioms ;)\n";
-      list decl_def oc (definitions()))
+      list decl_def oc !the_definitions)
 ;;
 
 let export_proofs b r =
@@ -848,9 +848,9 @@ eq : a : Set -> El a -> El a -> El bool.\n";
   string oc "\n(; constants ;)\n";
   list decl_sym oc constants;
   string oc "\n(; axioms ;)\n";
-  decl_axioms oc (axioms());
+  decl_axioms oc !the_axioms;
   string oc "\n(; definitions ;)\n";
-  list decl_def oc (definitions());
+  list decl_def oc !the_definitions;
   string oc "\n"
 ;;
 

--- a/xlp.ml
+++ b/xlp.ml
@@ -491,7 +491,7 @@ let proof tvs rmap =
     | Pinstt(k,s) -> subproof tvs rmap s [] ts k oc (proof_at k)
     | Paxiom(t) ->
       string oc "@axiom_";
-      int oc (pos_first (fun th -> concl th = t) (axioms()));
+      int oc (pos_first (fun th -> concl th = t) !the_axioms);
       list_prefix " " typ oc (type_vars_in_term t);
       list_prefix " " term oc (frees t)
     | Pdef(t,n,_) ->
@@ -499,7 +499,7 @@ let proof tvs rmap =
        list_prefix " " typ oc (type_vars_in_term t)
     | Pdeft(_,t,_,_) ->
       string oc "@axiom_";
-      int oc (pos_first (fun th -> concl th = t) (axioms()));
+      int oc (pos_first (fun th -> concl th = t) !the_axioms);
       list_prefix " " typ oc (type_vars_in_term t);
       list_prefix " " term oc (frees t)
     | Ptruth -> string oc "Tᵢ"
@@ -569,7 +569,7 @@ let definition_of n =
     | Comb(Comb(Const("=",_),Const(n',_)),r) ->
        if n'=n then Some(t,r) else None
     | _ -> assert false
-  in List.find_map f (definitions())
+  in List.find_map f !the_definitions
 ;;
 
 let decl_sym oc (n,b) =
@@ -1066,7 +1066,7 @@ let export_terms b =
 
 let export_axioms b =
   export (b^"_axioms") [b^"_types"; b^"_terms"]
-    (fun oc -> decl_axioms oc (axioms()))
+    (fun oc -> decl_axioms oc !the_axioms)
 ;;
 
 (* Used in single file generation. Generate b_proofs.lp. *)


### PR DESCRIPTION
- hol2dk dump: always generate the same file dump.ml instead of a different file each time
- fusion.ml as used in hol-light: always dump proofs in the same file dump.prf instead of a different file each time
- fusion.ml as used in hol2dk: do not generate a dump file