### PR TITLE
include dependencies of hol.ml when dumping a file after hol.ml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,16 +54,12 @@ lpsig: $(BASE_FILES:%=%.lp)
 $(BASE_FILES:%=%.lp) &:
 	$(HOL2DK) sig $(BASE).lp
 
+.PHONY: vsig
+vsig: $(BASE_FILES:%=%.v)
+
 .PHONY: sig
-sig: $(BASE_FILES:%=%.vo)
-
-.PRECIOUS: $(BASE_FILES:%=%.v)
-
-include deps.mk
-theory_hol.vo: $(VOFILES)
-$(BASE)_types.vo: theory_hol.vo
-$(BASE)_terms: $(BASE)_type_abbrevs.vo
-$(BASE)_axioms: $(BASE)_terms.vo
+sig: vsig
+	$(MAKE) INCLUDE_VO_MK=1 $(BASE_FILES:%=%.vo)
 
 .PHONY: single
 single: $(BASE).lp
@@ -245,7 +241,8 @@ ifeq ($(INCLUDE_VO_MK),1)
 include vo.mk
 
 vo.mk: lpo.mk
-	sed -e 's/\.lp/.v/g' -e "s/^theory_hol.vo:/theory_hol.vo: $(VOFILES) /" lpo.mk > $@
+	cp deps.mk $@
+	sed -e 's/\.lp/.v/g' -e "s/^theory_hol.vo:/theory_hol.vo: $(VOFILES) /" lpo.mk >> $@
 endif
 
 .PHONY: dep

--- a/Makefile
+++ b/Makefile
@@ -49,21 +49,15 @@ rm-thp:
 BASE_FILES := $(BASE)_types $(BASE)_terms $(BASE)_axioms
 
 .PHONY: lpsig
-lpsig: $(BASE_FILES:%=%.lp) $(BASE)_type_abbrevs.lp
+lpsig: $(BASE_FILES:%=%.lp)
 
 $(BASE_FILES:%=%.lp) &:
 	$(HOL2DK) sig $(BASE).lp
 
-.PHONY: type_abbrevs
-type_abbrevs: $(BASE)_type_abbrevs.lp
-
-$(BASE)_type_abbrevs.lp:
-	$(HOL2DK) type_abbrevs $(BASE)
-
 .PHONY: sig
 sig: $(BASE_FILES:%=%.vo)
 
-.PRECIOUS: $(BASE_FILES:%=%.v) $(BASE)_type_abbrevs.v
+.PRECIOUS: $(BASE_FILES:%=%.v)
 
 include deps.mk
 theory_hol.vo: $(VOFILES)
@@ -119,7 +113,7 @@ find-big-files:
 	@sort -u /tmp/big-files
 
 .PHONY: lp
-lp: $(BASE_FILES:%=%.lp) $(BASE)_type_abbrevs.lp $(BIG_FILES:%=%.max)
+lp: $(BASE_FILES:%=%.lp) $(BIG_FILES:%=%.max)
 	$(MAKE) SET_STI_FILES=1 SET_IDX_FILES=1 lp-proofs
 	$(MAKE) SET_MIN_FILES=1 lp-abbrevs
 	$(HOL2DK) type_abbrevs $(BASE)

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(BASE_FILES:%=%.lp) &:
 	$(HOL2DK) sig $(BASE).lp
 
 .PHONY: sig
-sig: $(BASE_FILES:%=%.lp)
+sig: $(BASE_FILES:%=%.vo)
 
 .PHONY: single
 single: $(BASE).lp
@@ -308,24 +308,24 @@ all:
 	$(MAKE) v
 	$(MAKE) vo
 
-.PHONY: vtodo
-vtodo:
+.PHONY: votodo
+votodo:
 	find . -name '*.v' | sort > /tmp/vfiles
 	find . -name '*.vo' | sed -e 's/\.vo$$/.v/' | sort > /tmp/vofiles
-	diff /tmp/vofiles /tmp/vfiles | sed -e '/^[^>]/d' -e 's/^> .\///' > vtodo
-	@export v=`wc -l vtodo | sed -e 's/ vtodo//'`; export n=`find . -name \*.v | wc -l`; echo remains $$v/$$n=`expr $${v}00 / $$n`\% 
+	diff /tmp/vofiles /tmp/vfiles | sed -e '/^[^>]/d' -e 's/^> .\///' > votodo
+	@export v=`wc -l votodo | sed -e 's/ votodo//'`; export n=`find . -name \*.v | wc -l`; echo remains $$v/$$n=`expr $${v}00 / $$n`\% 
 
 .PHONY: lptodo
-lptodo: vtodo
-	sed -e 's/\.v$$/.lp/' vtodo > lptodo
+lptodo: votodo
+	sed -e 's/\.v$$/.lp/' votodo > lptodo
 
 .PHONY: clean-lptodo
 clean-lptodo: lptodo
 	xargs -a lptodo rm -f
 
-.PHONY: clean-vtodo
-clean-vtodo: vtodo
-	xargs -a vtodo rm -f
+.PHONY: clean-votodo
+clean-votodo: votodo
+	xargs -a votodo rm -f
 
 .PHONY: lpsize
 lpsize:

--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,8 @@ rm-cache:
 	rm -f .lia.cache .nia.cache
 
 .PHONY: opam
-opam: $(BASE)_opam.vo
+opam:
+	$(MAKE) INCLUDE_VO_MK=1 $(BASE)_opam.vo
 
 .PRECIOUS: $(BASE)_opam.v
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ sig: $(BASE_FILES:%=%.vo)
 include deps.mk
 theory_hol.vo: $(VOFILES)
 $(BASE)_types.vo: theory_hol.vo
-$(BASE)_type_abbrevs: $(BASE)_types.vo
 $(BASE)_terms: $(BASE)_type_abbrevs.vo
 $(BASE)_axioms: $(BASE)_terms.vo
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ For instance, to translate the Multivariate library using the Coq type N for nat
 ```
 mkdir output
 cd output
-hol2dk config Multivariate/make_complex.ml HOLLight HOLLight_Real_With_N.mappings $HOL2DK_DIR/With_N.v BinNat Rbase Rdefinitions Rbasic_fun $HOL2DK_DIR/With_N.mk $HOL2DK_DIR/With_N.lp
+hol2dk config Multivariate/make_complex.ml HOLLight HOLLight_Real_With_N.mappings $HOL2DK_DIR/With_N.v Coq.NArith.BinNat Coq.Reals.Rbase Coq.Reals.Rdefinitions Coq.Reals.Rbasic_fun $HOL2DK_DIR/With_N.mk $HOL2DK_DIR/With_N.lp
 ```
 
 - you can then do in order:

--- a/With_N.v
+++ b/With_N.v
@@ -2,7 +2,7 @@
 (* Proof that Coq R is a fourcolor.model of real numbers. *)
 (*****************************************************************************)
 
-Require Import HOLLight_Real_With_N.mappings Rbase Rdefinitions Rbasic_fun.
+Require Import HOLLight_Real_With_N.mappings Coq.Reals.Rbase Coq.Reals.Rdefinitions Coq.Reals.Rbasic_fun.
 
 Open Scope R_scope.
 
@@ -189,7 +189,7 @@ Proof.
   unfold eq. rewrite thm_REAL_LE_ANTISYM. reflexivity.
 Qed.
 
-Require Import Lia.
+Require Import Coq.micromega.Lia.
 
 Lemma real_axioms : axioms real_struct.
 Proof.
@@ -345,7 +345,7 @@ Definition R_of_N n :=
   | N.pos p => IPR p
   end.
 
-Require Import Lra.
+Require Import Coq.micromega.Lra.
 
 Lemma R_of_N_succ n : R_of_N (N.succ n) = (R_of_N n + 1)%R.
 Proof.
@@ -418,7 +418,7 @@ Proof.
   induction y; simpl. rewrite h0. reflexivity. rewrite hs, IHy. reflexivity.
 Qed.*)
 
-Require Import RIneq.
+Require Import Coq.Reals.RIneq.
 
 Open Scope R_scope.
 
@@ -570,7 +570,7 @@ Proof.
   intro p. simpl. lia.
 Qed.
 
-Require Import Lra R_Ifp.
+Require Import Coq.micromega.Lra Coq.Reals.R_Ifp.
 
 Lemma up_IZR z : up (IZR z) = (z + 1)%Z.
 Proof. symmetry; apply tech_up; rewrite plus_IZR; lra.
@@ -649,7 +649,7 @@ Proof.
   right. exists a. exists s. split. reflexivity. apply IHh. exact H.  
 Qed.
 
-Require Import List.
+Require Import Coq.Lists.List.
 
 Lemma finite_list_NoDup {A:Type'} (s:A -> Prop):
   finite s = (exists l, NoDup l /\ s = fun x => In x l).
@@ -705,7 +705,7 @@ Proof.
   rewrite e. simpl. left. reflexivity.
 Qed.
 
-Require Import Permutation.
+Require Import Coq.Sorting.Permutation.
 
 Lemma eq_mod_permut A (l: list A):
   forall l', (forall x, In x l = In x l') -> NoDup l -> NoDup l' -> Permutation l l'.

--- a/With_nat.v
+++ b/With_nat.v
@@ -2,7 +2,7 @@
 (* Proof that Coq R is a fourcolor.model of real numbers. *)
 (*****************************************************************************)
 
-Require Import HOLLight_Real_With_nat.mappings Rbase Rdefinitions Rbasic_fun.
+Require Import HOLLight_Real_With_nat.mappings Coq.Reals.Rbase Coq.Reals.Rdefinitions Coq.Reals.Rbasic_fun.
 
 Open Scope R_scope.
 
@@ -334,7 +334,7 @@ Proof. rewrite <- eq_real_model. apply (morph_one real_of_R_morph). Qed.
 Lemma one_eq : 1%R = R_of_real (real_of_num 1).
 Proof. rewrite <- one_morph_R, R_of_real_of_R. reflexivity. Qed.
 
-Require Import Lia.
+Require Import Coq.micromega.Lia.
 
 Lemma real_of_num_def : INR = (fun m : nat => mk_real (fun u : prod hreal hreal => treal_eq (treal_of_num m) u)).
 Proof.
@@ -361,7 +361,7 @@ Proof.
   induction y; simpl. rewrite h0. reflexivity. rewrite hs, IHy. reflexivity.
 Qed.
 
-Require Import RIneq.
+Require Import Coq.Reals.RIneq.
 
 Open Scope R_scope.
 
@@ -466,7 +466,7 @@ Proof.
   apply IZR_integer. exists (int_of_real r). symmetry. exact h.
 Qed.
 
-Require Import Lra R_Ifp.
+Require Import Coq.micromega.Lra Coq.Reals.R_Ifp.
 
 Lemma up_IZR z : up (IZR z) = (z + 1)%Z.
 Proof. symmetry; apply tech_up; rewrite plus_IZR; lra.
@@ -545,7 +545,7 @@ Proof.
   right. exists a. exists s. split. reflexivity. apply IHh. exact H.  
 Qed.
 
-Require Import List.
+Require Import Coq.Lists.List.
 
 Lemma finite_list_NoDup {A:Type'} (s:A -> Prop):
   finite s = (exists l, NoDup l /\ s = fun x => In x l).
@@ -601,7 +601,7 @@ Proof.
   rewrite e. simpl. left. reflexivity.
 Qed.
 
-Require Import Permutation.
+Require Import Coq.Sorting.Permutation.
 
 Lemma eq_mod_permut A (l: list A):
   forall l', (forall x, In x l = In x l') -> NoDup l -> NoDup l' -> Permutation l l'.

--- a/main.ml
+++ b/main.ml
@@ -352,6 +352,8 @@ let dump after_hol f b =
     if after_hol then out oc "#use \"hol.ml\";;\nneeds \"%s\";;" f
     else out oc "#use \"%s\";;" f
   in
+  let dg = dep_graph (files()) in
+  let deps = trans_file_deps dg (if after_hol then ["hol.ml";f] else [f]) in
   let cmd oc after_hol =
     if after_hol then out oc " dump" else out oc " dump-before-hol" in
   out oc
@@ -361,15 +363,14 @@ let dump after_hol f b =
 #require "zarith";;
 #require "unix";;
 #load "bignum.cmo";;
-let dump_filename = "%s.prf";; 
+let dump_filename = "%s.prf";;
 %a
 close_out oc_dump;;
 dump_nb_proofs "%s.nbp";;
 dump_signature "%s.sig";;
 #use "xnames.ml";;
 dump_map_thid_name "%s.thm" %a;;
-|} cmd after_hol f b use after_hol b b b
-(olist ostring) (trans_file_deps (dep_graph (files())) f);
+|} cmd after_hol f b use after_hol b b b (olist ostring) deps;
   close_out oc;
   Sys.command ("ocaml -w -A -I . "^ml_file)
 ;;
@@ -451,7 +452,7 @@ and command = function
   (* Print dependencies of the ml file f. *)
   | ["dep";f] ->
      let dg = dep_graph (files()) in
-     log "%a\n" (list_sep " " string) (trans_file_deps dg f);
+     log "%a\n" (list_sep " " string) (trans_file_deps dg [f]);
      0
 
   (* Print dependencies of all ml files in the current directory and
@@ -472,7 +473,7 @@ and command = function
      let dg = dep_graph (files()) in
      List.iter
        (fun d -> List.iter (log "%s %s\n" d) (thms_of_file d))
-       (trans_file_deps dg f);
+       (trans_file_deps dg [f]);
      0
 
   (* Print the names of theorems proved in all files in the current

--- a/xfiles.ml
+++ b/xfiles.ml
@@ -63,9 +63,9 @@ let out_dep_graph oc dg =
 (* [file_deps dg f] returns the immediate dependencies of [f] in [dg]. *)
 let file_deps dg filename = try MapStr.find filename dg with Not_found -> [];;
 
-(* [trans_deps dg f] returns all the dependencies of [f] in [dg],
-   recursively. *)
-let trans_file_deps dg filename =
+(* [trans_deps dg filenames] returns all the dependencies of
+   [filenames] in [dg], recursively. *)
+let trans_file_deps dg filenames =
   let rec trans visited to_visit =
     match to_visit with
     | [] -> List.rev visited
@@ -76,7 +76,7 @@ let trans_file_deps dg filename =
          if List.for_all (fun f -> List.mem f visited) fs then
            trans (f :: visited) to_visit
          else trans visited (fs @ f :: to_visit)
-  in trans [] [filename]
+  in trans [] filenames
 ;;
 
 (* unit test *)
@@ -85,4 +85,4 @@ let _ =
     List.fold_left (fun dg (f,deps) -> MapStr.add f deps dg) MapStr.empty
       ["a",["b";"c"]; "b",["d";"e"]; "c",["f";"g"]]
   in
-  assert (trans_file_deps dg "a" = ["d";"e";"b";"f";"g";"c";"a"])
+  assert (trans_file_deps dg ["a"] = ["d";"e";"b";"f";"g";"c";"a"])


### PR DESCRIPTION
- Xfiles.trans_file_deps takes as argument a list of filenames instead of a single filename
- main.ml: include dependencies of hol.ml when dumping a file after hol.ml
- With_N.v and With_nat.v: qualify Coq modules
- Makefile: rename vtodo into votodo, and sig into lpsig
- Makefile: remove `$(BASE)_type_abbrevs` from `$(BASE_FILES)`
- Makefile: add targets vsig and sig to build `$(BASE_FILES:%=%.v)` and `$(BASE_FILES:%=%.vo)`

