### PR TITLE
detect duplicated theorems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - command files to print theorem statements following the file structuration in HOL-Light
 - command thms to print theorems (named or not) proved in a file
 - command unsplit to put the proofs of all the theorems proved in a HOL-Light file in the same Lambdapi file
+- command concl to print the statements of theorems between two indexes
+- option --max-dup $k to share the proof of a theorem if it is duplicated more than $k times
 - renamings to handle the Multivariate library
 - test/Sig_mappings_N.v and test/Sig_With_N.v: axiomatizations of mappings_N.v and With_N.v respectively
 

--- a/fusion.ml
+++ b/fusion.ml
@@ -183,8 +183,7 @@ module Hol : Hol_kernel = struct
             | Abs of term * term
 
 
-  type thm = Sequent of (term list * term * int)
-  (*REMOVE*)let dummy_thm = Sequent([],Var("x",Tyvar("a")),0)
+  type [@warning "-37"] thm = Sequent of (term list * term * int)
 
 (*---------------------------------------------------------------------------*)
 (* Proof dumping.                                                            *)

--- a/main.ml
+++ b/main.ml
@@ -22,7 +22,7 @@ Options
 
 --root-path MODNAME: set lambdapi and coq's root_path (default is HOLLight)
 
---max-dup INT: maximum number of proof step duplications
+--max-dup INT: maximum number of theorem duplications
 
 --max-proof-size INT: maximum size of proof files (default is 500_000)
 

--- a/xlib.ml
+++ b/xlib.ml
@@ -772,6 +772,34 @@ let canonical_term
 (* Functions on proofs. *)
 (****************************************************************************)
 
+(* rename theorem indexes according to [map]. *)
+let rename_pc map pc =
+  let rename i = try MapInt.find i map with Not_found -> i in
+  match pc with
+  | Ptrans(i,j) -> Ptrans(rename i,rename j)
+  | Pmkcomb(i,j) -> Pmkcomb(rename i,rename j)
+  | Pabs(i,t) -> Pabs(rename i,t)
+  | Peqmp(i,j) -> Peqmp(rename i,rename j)
+  | Pdeduct(i,j) -> Pdeduct(rename i,rename j)
+  | Pinst(i,s) -> Pinst(rename i,s)
+  | Pinstt(i,s) -> Pinstt(rename i,s)
+  | Pdeft(i,t,s,a) -> Pdeft(rename i,t,s,a)
+  | Pconj(i,j) -> Pconj(rename i,rename j)
+  | Pconjunct1 i -> Pconjunct1(rename i)
+  | Pconjunct2 i -> Pconjunct2(rename i)
+  | Pmp(i,j) -> Pmp(rename i,rename j)
+  | Pdisch(t,i) -> Pdisch(t,rename i)
+  | Pspec(t,i) -> Pspec(t,rename i)
+  | Pgen(t,i) -> Pgen(t,rename i)
+  | Pexists(t,u,i) -> Pexists(t,u,rename i)
+  | Pchoose(t,i,j) -> Pchoose(t,rename i,rename j)
+  | Pdisj1(t,i) -> Pdisj1(t,rename i)
+  | Pdisj2(t,i) -> Pdisj2(t,rename i)
+  | Pdisj_cases(i,j,k) -> Pdisj_cases(rename i,rename j,rename k)
+  | Psym i -> Psym(rename i)
+  | Prefl _ | Pbeta _ | Passume _ | Paxiom _ | Pdef _ | Ptruth -> pc
+;;
+
 (* [size_content nb_type_vars nb_term_vars content] computes an
    approximation of the tree size of the Dedukti representation of the
    proof [content]. *)


### PR DESCRIPTION
- add command concl to print the statements of theorems between two indexes
- add option --max-dup to set the maximum number of theorem duplications before sharing their proofs
- rewrite command: share its proof when a theorem is duplicated too many times (option --max-dup)
- Main.command: do not return an exit code anymore 