### PR TITLE
rocq compile options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ ifneq ($(INCLUDE_VO_MK),1)
 	touch .finished
 endif
 
-BASE_ROCQ_OPTIONS := -q -no-glob -R . $(ROOT_PATH) 
+BASE_ROCQ_OPTIONS := -q -no-glob -R . $(ROOT_PATH)
 # User specifiable rocq options
 EXTRA_ROCQ_OPTIONS ?=
 ROCQ_OPTIONS := $(BASE_ROCQ_OPTIONS) $(EXTRA_ROCQ_OPTIONS)


### PR DESCRIPTION
Add the possibility to add extra arguments to rocq compile in make vo.
examples: 
`make EXTRA_ROCQ_OPTIONS="-w -redundant-canonical-projection -w -notation-overridden -w -ambiguous-paths" vo`
`export EXTRA_ROCQ_OPTIONS="-w -redundant-canonical-projection -w -notation-overridden -w -ambiguous-paths"
make vo`
are equivalent and remove the warnings in question during make vo